### PR TITLE
IBX-538: Replaced EzPublishCore Twig namespace references with IbexaCore

### DIFF
--- a/src/bundle/Resources/views/fields/content_fields.html.twig
+++ b/src/bundle/Resources/views/fields/content_fields.html.twig
@@ -1,6 +1,6 @@
 {% trans_default_domain "content_fields" %}
 
-{% extends "@EzPublishCore/content_fields.html.twig" %}
+{% extends "@IbexaCore/content_fields.html.twig" %}
 
 {% block ezobjectrelationlist_field %}
     {% apply spaceless %}


### PR DESCRIPTION
| Question                                  | Answer
| ---------------------------------------- | ------------------
| **JIRA issue**                          | [IBX-538](https://issues.ibexa.co/browse/IBX-538)
| **Requires**                            | ibexa/core#13
| **Type**                                   | feature
| **Target Ibexa version** | `v4.0`
| **BC breaks**                          | yes

ibexa/core#13 updates `ibexa/core` Bundle names with proper Ibexa prefix instead of EzPublish. This PR aligns Twig namespace references with the bundle name change.

#### Checklist:
- [x] Provided PR description.
- [x] Tested the solution manually.
- [ ] Asked for a review