### PR TITLE
IBX-1589: Renamed Extension ez_platform_http_cache to ibexa_http_cache

### DIFF
--- a/docs/extensibility.md
+++ b/docs/extensibility.md
@@ -20,7 +20,7 @@ class MyCustomBundle
 {
   public function build(ContainerBuilder $container)
   {
-    $cacheExtension = $container->getExtension('ez_platform_http_cache');
+    $cacheExtension = $container->getExtension('ibexa_http_cache');
     $cacheExtension->addExtraConfigParser(new CustomConfigParser());
   }
 }

--- a/src/bundle/DependencyInjection/Configuration.php
+++ b/src/bundle/DependencyInjection/Configuration.php
@@ -21,7 +21,7 @@ class Configuration implements ConfigurationInterface
      */
     public function getConfigTreeBuilder()
     {
-        return new TreeBuilder('ez_platform_http_cache');
+        return new TreeBuilder('ibexa_http_cache');
     }
 }
 

--- a/src/bundle/DependencyInjection/IbexaHttpCacheExtension.php
+++ b/src/bundle/DependencyInjection/IbexaHttpCacheExtension.php
@@ -25,7 +25,7 @@ class IbexaHttpCacheExtension extends Extension implements PrependExtensionInter
 
     public function getAlias()
     {
-        return 'ez_platform_http_cache';
+        return 'ibexa_http_cache';
     }
 
     public function load(array $configs, ContainerBuilder $container)

--- a/src/bundle/IbexaHttpCacheBundle.php
+++ b/src/bundle/IbexaHttpCacheBundle.php
@@ -61,7 +61,7 @@ class IbexaHttpCacheBundle extends Bundle
         $eZExtension = $container->getExtension('ezpublish');
         $eZExtension->addConfigParser(
             new HttpCacheConfigParser(
-                $container->getExtension('ez_platform_http_cache')
+                $container->getExtension('ibexa_http_cache')
             )
         );
     }


### PR DESCRIPTION
| Question                                  | Answer
| ---------------------------------------- | ------------------
| **JIRA issue**                          | [IBX-1589](https://issues.ibexa.co/browse/IBX-1589)
| **Type**                                   | feature
| **Target Ibexa version** | `v4.0`
| **BC breaks**                          | yes, requires ibexa/compatibility-layer#5

- [x] IBX-1589: Renamed Extension ez_platform_http_cache to ibexa_http_cache

#### Checklist:
- [x] Provided PR description.
- [x] Tested the solution manually.
- ~Provided automated test coverage.~ // full stack Behat coverage
- [ ] Ran PHP CS Fixer for new PHP code (use `$ composer fix-cs`).
- [ ] Asked for a review
