### PR TITLE
IBX-1694: Rebranded dependency injection container service tags

### DIFF
--- a/docs/drivers.md
+++ b/docs/drivers.md
@@ -23,10 +23,10 @@ services:
         class: EzSystems\PlatformMyHttpCacheBundle\PurgeClient\MyHttpCachePurgeClient
         arguments: ['@ezplatform.http_cache.cache_manager']
         tags:
-            - {name: ezplatform.http_cache.purge_client, purge_type: myhttpcache}
+            - {name: ibexa.cache.http.purge_client, purge_type: myhttpcache}
 ```
 
-Any service which implements the PurgeClientInterface must be tagged with `ezplatform.http_cache.purge_client` in
+Any service which implements the PurgeClientInterface must be tagged with `ibexa.cache.http.purge_client` in
 order to be registered as such.
 
 `purge_type` specifies what the value of the `ezpublish.http_cache.purge_type` setting in `app/config/ezplatform.yml`

--- a/src/bundle/DependencyInjection/Compiler/DriverPass.php
+++ b/src/bundle/DependencyInjection/Compiler/DriverPass.php
@@ -21,7 +21,7 @@ class DriverPass implements CompilerPassInterface
         $container->removeAlias('ezpublish.http_cache.purge_client');
 
         $purgeType = $container->getParameter('ezpublish.http_cache.purge_type');
-        $configuredPurgeClientServiceId = static::getTaggedService($container, 'ezplatform.http_cache.purge_client');
+        $configuredPurgeClientServiceId = static::getTaggedService($container, 'ibexa.cache.http.purge_client');
         if ($configuredPurgeClientServiceId === null) {
             throw new \InvalidArgumentException("No driver found being able to handle purge_type '$purgeType'.");
         }

--- a/src/bundle/DependencyInjection/Compiler/ResponseTaggersPass.php
+++ b/src/bundle/DependencyInjection/Compiler/ResponseTaggersPass.php
@@ -11,7 +11,7 @@ use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Reference;
 
 /**
- * Processes services tagged as ezplatform.cache_response_tagger, and registers them with the dispatcher.
+ * Injects services tagged as "ibexa.cache.http.response.tagger" into the dispatcher.
  */
 class ResponseTaggersPass implements CompilerPassInterface
 {
@@ -23,7 +23,7 @@ class ResponseTaggersPass implements CompilerPassInterface
 
         $taggers = [];
 
-        $taggedServiceIds = $container->findTaggedServiceIds('ezplatform.cache_response_tagger');
+        $taggedServiceIds = $container->findTaggedServiceIds('ibexa.cache.http.response.tagger');
         foreach ($taggedServiceIds as $taggedServiceId => $tags) {
             $taggers[] = new Reference($taggedServiceId);
         }

--- a/src/bundle/Resources/config/services.yml
+++ b/src/bundle/Resources/config/services.yml
@@ -43,13 +43,13 @@ services:
         arguments:
             - '@fos_http_cache.cache_manager'
         tags:
-            - {name: ezplatform.http_cache.purge_client, purge_type: varnish}
+            - {name: ibexa.cache.http.purge_client, purge_type: varnish}
 
     ezplatform.http_cache.purge_client.local:
         class: Ibexa\HttpCache\PurgeClient\LocalPurgeClient
         arguments: ['@ezplatform.http_cache.tag_aware_store']
         tags:
-            - {name: ezplatform.http_cache.purge_client, purge_type: local}
+            - {name: ibexa.cache.http.purge_client, purge_type: local}
 
     ezplatform.http_cache.tag_aware_store:
         class: Toflar\Psr6HttpCacheStore\Psr6Store

--- a/src/bundle/Resources/config/view_cache.yml
+++ b/src/bundle/Resources/config/view_cache.yml
@@ -67,13 +67,13 @@ services:
         class: Ibexa\HttpCache\ResponseTagger\Delegator\ContentValueViewTagger
         arguments: ['@ezplatform.view_cache.response_tagger.content_info']
         tags:
-            - {name: ezplatform.cache_response_tagger}
+            - {name: ibexa.cache.http.response.tagger}
 
     ezplatform.view_cache.response_tagger.location_value_view:
         class: Ibexa\HttpCache\ResponseTagger\Delegator\LocationValueViewTagger
         arguments: ['@ezplatform.view_cache.response_tagger.location']
         tags:
-            - {name: ezplatform.cache_response_tagger}
+            - {name: ibexa.cache.http.response.tagger}
 
     # ResponseTagger value handlers
     ezplatform.view_cache.response_tagger.abstract_value:
@@ -84,13 +84,13 @@ services:
         class: Ibexa\HttpCache\ResponseTagger\Value\ContentInfoTagger
         parent: ezplatform.view_cache.response_tagger.abstract_value
         tags:
-            - {name: ezplatform.cache_response_tagger}
+            - {name: ibexa.cache.http.response.tagger}
 
     ezplatform.view_cache.response_tagger.location:
         class: Ibexa\HttpCache\ResponseTagger\Value\LocationTagger
         parent: ezplatform.view_cache.response_tagger.abstract_value
         tags:
-            - {name: ezplatform.cache_response_tagger}
+            - {name: ibexa.cache.http.response.tagger}
 
     # Twig
     ezplatform.view_cache.twig_extension:


### PR DESCRIPTION
| Question                                  | Answer
| ---------------------------------------- | ------------------
| **JIRA issue**                          | [IBX-1694](https://issues.ibexa.co/browse/IBX-1694)
| **Type**                                   | feature
| **Target Ibexa version** | `v4.0`
| **BC breaks**                          | yes, requires ibexa/compatibility-layer#12

In this Pull Request we rename Ibexa's dependency injection container service tags according to the map provided by ibexa/compatibility-layer#12 as a part of the rebranding process. Backward compatibility for old service tags is provided by ibexa/compatibility-layer#12.

#### Checklist:
- [x] Provided PR description.
- [x] Tested the solution manually.
- [ ] Provided automated test coverage.
- [x] Asked for a review
