### PR TITLE
[Behat] Adjusted pattern to rebranding

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
     ],
     "require": {
         "php": "^7.4 || ^8.0",
-        "ibexa/core": "^4.0@dev",
+        "ibexa/core": "^4.0.x-dev",
         "ibexa/rest": "^4.0@dev",
         "friendsofsymfony/http-cache-bundle": "^2.8",
         "friendsofsymfony/http-cache": "^2.9",

--- a/features/setup/setup.feature
+++ b/features/setup/setup.feature
@@ -24,7 +24,7 @@ Feature: Set system to desired state before tests
     And I create "embeddingContentType_esi" Content items in root in "eng-GB"
       | name             | relation         |
       | EmbeddingItemEsi | /EmbeddedItemEsi |
-    And I set configuration to "ezplatform.system.default.content_view"
+    And I set configuration to "ibexa.system.default.content_view"
     """
       full:
         embeddingContentType_no_esi:

--- a/features/symfony/cache.feature
+++ b/features/symfony/cache.feature
@@ -48,5 +48,5 @@ Feature: As an site administrator I want my pages to be cached using Symfony Htt
 
     Examples:
       | user      | password | itemName        | itemNameAfterEdit | headerValue                      |
-      | admin     | publish  | NameToEditAdmin | NameEditedAdmin   | GET /site/nameeditedadmin: fresh |
-      | anonymous |          | NameToEditAnon  | NameEditedAnon    | GET /site/nameeditedanon: fresh  |
+      | admin     | publish  | NameToEditAdmin | NameEditedAdmin   | GET /nameeditedadmin: fresh |
+      | anonymous |          | NameToEditAnon  | NameEditedAnon    | GET /nameeditedanon: fresh  |

--- a/features/symfony/embed.feature
+++ b/features/symfony/embed.feature
@@ -38,7 +38,6 @@ Feature: Caching of embedded items
       | admin     | publish  | EmbeddingItemAdmin | AdminEmbeddedItem | EditedEmbeddedItemAdmin | GET /site/embeddingitemadmin: fresh |
       | anonymous |          | EmbeddingItemAnon  | AnonEmbeddedItem  | EditedEmbeddedItemAnon  | GET /site/embeddingitemanon: fresh  |
 
-
   Scenario Outline: Embedded requests are cached
     Given I am viewing the pages on siteaccess "site" as "admin" with password "publish"
     And I start measuring time
@@ -61,4 +60,4 @@ Feature: Caching of embedded items
     Examples:
       | embeddingItemName  | embeddedItemName  | expectedPattern |
       | EmbeddingItemNoEsi | EmbeddedItemNoEsi | /GET \/site\/embeddingitemnoesi\: fresh/ |
-      | EmbeddingItemEsi   | EmbeddedItemEsi   | /GET \/site\/embeddingitemesi\: fresh; GET \/_fragment\?_hash\=.*%3D&_path\=contentId%3D53%26viewType%3Dline%26_format%3Dhtml%26_locale%3Den_GB%26_controller%3Dez_content%253A%253AviewAction\: fresh/ |
+      | EmbeddingItemEsi   | EmbeddedItemEsi   | /GET \/site\/embeddingitemesi\: fresh; GET \/.*\: fresh/ |


### PR DESCRIPTION
For some reason the tests are failing: https://github.com/ibexa/http-cache/runs/5035125358?check_suite_focus=true

```
In PrioritizedResourceManager.php line 70:
                                                                               
  Can not find appropriate suite scope for class `Ibexa\Contracts\Core\SiteAc  
  cess\ConfigResolverInterface`.     
```
because `  - Locking ibexa/core (v4.0.0-rc1)` is installed

I've changed it to `         "ibexa/core": "^4.0.x-dev",` so that correct ibexa/core version is used.


I've adjusted the regex so that it checks only the part that's needed (`fresh`) and is less prone to future rebranding changes.