### PR TITLE
IBX-1696: Rebranded Container parameters and Config Resolver namespaces

### DIFF
--- a/docs/drivers.md
+++ b/docs/drivers.md
@@ -29,13 +29,8 @@ services:
 Any service which implements the PurgeClientInterface must be tagged with `ibexa.cache.http.purge_client` in
 order to be registered as such.
 
-`purge_type` specifies what the value of the `ezpublish.http_cache.purge_type` setting in `app/config/ezplatform.yml`
-should be in order to enable this driver. By default this is set using `%purge_type%` parameter, and can be set in `app/config/parameters.yml` like so:
-
-```
-parameters:
-    purge_type: myhttpcache
-```
+`purge_type` specifies what the value of the `ibexa.http_cache.purge_type` setting in `config/packages/ibexa.yaml`
+should be in order to enable this driver. By default this is set using `%purge_type%` parameter.
 
 
 ## TagHandler

--- a/docs/using_tags.md
+++ b/docs/using_tags.md
@@ -254,7 +254,7 @@ If that is not an option, you can opt-in to set a max length parameter (in bytes
 ```yaml
 parameters:
     # Warning, setting this means you risk losing tag information, risking stale cache. Here set below 8k:
-    ezplatform.http_cache.tags.header_max_length: 7900
+    ibexa.http_cache.tags.header_max_length: 7900
     # In order to reduce risk of stale cache issues, you should set a lower TTL here then globally (here set as 2h)
-    ezplatform.http_cache.tags.header_reduced_ttl: 7200
+    ibexa.http_cache.tags.header_reduced_ttl: 7200
 ```

--- a/spec/DependencyInjection/Compiler/KernelPassSpec.php
+++ b/spec/DependencyInjection/Compiler/KernelPassSpec.php
@@ -55,8 +55,7 @@ class KernelPassSpec extends ObjectBehavior
 //            ]
 //        ])->shouldBeCalled();
 //
-//        $container->getParameter('ezpublish.http_cache.purge_type')->shouldBeCalled();
-//        $container->setParameter('ezplatform.http_cache.purge_type', null)->shouldBeCalled();
+//        $container->getParameter('ibexa.http_cache.purge_type')->shouldBeCalled();
 //
 //        $this->process($container);
 //    }

--- a/src/bundle/DependencyInjection/Compiler/DriverPass.php
+++ b/src/bundle/DependencyInjection/Compiler/DriverPass.php
@@ -21,7 +21,7 @@ class DriverPass implements CompilerPassInterface
     {
         $container->removeAlias('ezpublish.http_cache.purge_client');
 
-        $purgeType = $container->getParameter('ezpublish.http_cache.purge_type');
+        $purgeType = $container->getParameter('ibexa.http_cache.purge_type');
         $configuredPurgeClientServiceId = static::getTaggedService($container, 'ibexa.cache.http.purge_client');
         if ($configuredPurgeClientServiceId === null) {
             throw new \InvalidArgumentException("No driver found being able to handle purge_type '$purgeType'.");
@@ -43,7 +43,7 @@ class DriverPass implements CompilerPassInterface
 
     public static function getTaggedService(ContainerBuilder $container, $tag)
     {
-        $purgeType = $container->getParameter('ezpublish.http_cache.purge_type');
+        $purgeType = $container->getParameter('ibexa.http_cache.purge_type');
         $configuredTagHandlerServiceId = null;
 
         $tagHandlerServiceIds = $container->findTaggedServiceIds($tag);

--- a/src/bundle/DependencyInjection/Compiler/KernelPass.php
+++ b/src/bundle/DependencyInjection/Compiler/KernelPass.php
@@ -34,7 +34,7 @@ class KernelPass implements CompilerPassInterface
         $this->removeKernelRoleIdContextProvider($container);
 
         // Let's re-export purge_type setting so that driver's don't have to depend on kernel in order to acquire it
-        $container->setParameter('ezplatform.http_cache.purge_type', $container->getParameter('ezpublish.http_cache.purge_type'));
+        $container->setParameter('ibexa.http_cache.purge_type', $container->getParameter('ibexa.http_cache.purge_type'));
     }
 
     /**

--- a/src/bundle/DependencyInjection/Compiler/VarnishCachePass.php
+++ b/src/bundle/DependencyInjection/Compiler/VarnishCachePass.php
@@ -29,12 +29,12 @@ class VarnishCachePass implements CompilerPassInterface
         $baseUrl = $fosConfig['proxy_client']['varnish']['http']['base_url'] ?? '';
 
         $container->setParameter(
-            'ezplatform.http_cache.varnish.http.servers',
+            'ibexa.http_cache.varnish.http.servers',
             $servers
         );
 
         $container->setParameter(
-            'ezplatform.http_cache.varnish.http.base_url',
+            'ibexa.http_cache.varnish.http.base_url',
             $baseUrl
         );
     }

--- a/src/bundle/DependencyInjection/ConfigResolver/HttpCacheConfigParser.php
+++ b/src/bundle/DependencyInjection/ConfigResolver/HttpCacheConfigParser.php
@@ -30,7 +30,7 @@ class HttpCacheConfigParser implements ParserInterface
                 ->info('Settings related to Http cache')
                 ->children()
                     ->arrayNode('purge_servers')
-                        ->info('Servers to use for Http PURGE (will NOT be used if ezpublish.http_cache.purge_type is "local").')
+                        ->info('Servers to use for Http PURGE (will NOT be used if ibexa.http_cache.purge_type is "local").')
                         ->example(['http://localhost/', 'http://another.server/'])
                         ->requiresAtLeastOneElement()
                         ->prototype('scalar')->end()

--- a/src/bundle/DependencyInjection/IbexaHttpCacheExtension.php
+++ b/src/bundle/DependencyInjection/IbexaHttpCacheExtension.php
@@ -38,7 +38,7 @@ class IbexaHttpCacheExtension extends Extension implements PrependExtensionInter
         $loader->load('event.yml');
         $loader->load('view_cache.yml');
 
-        $purgeType = $container->getParameter('ezpublish.http_cache.purge_type');
+        $purgeType = $container->getParameter('ibexa.http_cache.purge_type');
         if ('local' === $purgeType) {
             $container->setParameter(
                 'fos_http_cache.tag_handler.response_header',

--- a/src/bundle/Resources/config/default_settings.yml
+++ b/src/bundle/Resources/config/default_settings.yml
@@ -1,4 +1,4 @@
 parameters:
-    ezplatform.http_cache.store.root: "%kernel.cache_dir%/http_cache"
-    ezplatform.http_cache.invalidate_token.ttl: 86400
-    ezplatform.http_cache.no_vary.routes: ['ezplatform.httpcache.invalidatetoken']
+    ibexa.http_cache.store.root: "%kernel.cache_dir%/http_cache"
+    ibexa.http_cache.invalidate_token.ttl: 86400
+    ibexa.http_cache.no_vary.routes: ['ezplatform.httpcache.invalidatetoken']

--- a/src/bundle/Resources/config/services.yml
+++ b/src/bundle/Resources/config/services.yml
@@ -1,13 +1,13 @@
 parameters:
     # Set in \Ibexa\Bundle\HttpCache\DependencyInjection\Compiler\VarnishCachePass
     # equal to settings under fos_http_cache.proxy_client.varnish.http.servers|base_url
-    ezplatform.http_cache.varnish.http.servers: []
-    ezplatform.http_cache.varnish.http.base_url: ~
+    ibexa.http_cache.varnish.http.servers: []
+    ibexa.http_cache.varnish.http.base_url: ~
     # Optional settings to set a max length parameter (in bytes, eg 7900) and corresponding ttl (in seconds, eg 3600)
     # Set  ttl to a low number as removing tags involves risk of stale responses (as it won't be purged on the tags removed)
     # NOTE: System will log warning when this happens so you can fix the given response to avoid the issue.
-    ezplatform.http_cache.tags.header_max_length: null
-    ezplatform.http_cache.tags.header_reduced_ttl: null
+    ibexa.http_cache.tags.header_max_length: null
+    ibexa.http_cache.tags.header_reduced_ttl: null
 
 services:
     Ibexa\HttpCache\ProxyClient\HttpDispatcherFactory:
@@ -22,8 +22,8 @@ services:
         lazy: true
         factory: ['@Ibexa\HttpCache\ProxyClient\HttpDispatcherFactory', 'buildHttpDispatcher']
         arguments:
-            $servers: '%ezplatform.http_cache.varnish.http.servers%'
-            $baseUrl: '%ezplatform.http_cache.varnish.http.base_url%'
+            $servers: '%ibexa.http_cache.varnish.http.servers%'
+            $baseUrl: '%ibexa.http_cache.varnish.http.base_url%'
 
     ibexa.http_cache.purge_client:
         alias: Ibexa\HttpCache\PurgeClient\RepositoryPrefixDecorator
@@ -51,7 +51,7 @@ services:
     Toflar\Psr6HttpCacheStore\Psr6Store:
         class: Toflar\Psr6HttpCacheStore\Psr6Store
         arguments:
-            - cache_directory: '%ezplatform.http_cache.store.root%'
+            - cache_directory: '%ibexa.http_cache.store.root%'
 
     Ibexa\HttpCache\Handler\TagHandler:
         class: Ibexa\HttpCache\Handler\TagHandler
@@ -61,8 +61,8 @@ services:
          - header_formatter: '@fos_http_cache.tag_handler.header_formatter'
            strict: '%fos_http_cache.tag_handler.strict%'
            # Custom eZ options (todo: Port to FOS)
-           tag_max_length: '%ezplatform.http_cache.tags.header_max_length%'
-           tag_max_length_ttl: '%ezplatform.http_cache.tags.header_reduced_ttl%'
+           tag_max_length: '%ibexa.http_cache.tags.header_max_length%'
+           tag_max_length_ttl: '%ibexa.http_cache.tags.header_reduced_ttl%'
 
     Ibexa\HttpCache\ContextProvider\RoleIdentify:
         class: Ibexa\HttpCache\ContextProvider\RoleIdentify
@@ -76,21 +76,21 @@ services:
     Ibexa\Bundle\HttpCache\Controller\InvalidateTokenController:
         arguments:
          - '@ibexa.config.resolver'
-         - "%ezplatform.http_cache.invalidate_token.ttl%"
+         - '%ibexa.http_cache.invalidate_token.ttl%'
          - "@fos_http_cache.http.symfony_response_tagger"
         tags:
             - controller.service_arguments
 
     Ibexa\HttpCache\EventListener\ConditionallyRemoveVaryHeaderListener:
         arguments:
-         - "%ezplatform.http_cache.no_vary.routes%"
+         - '%ibexa.http_cache.no_vary.routes%'
         tags:
             - { name: kernel.event_subscriber, priority: -100 }
 
     Ibexa\HttpCache\RepositoryTagPrefix:
         class: Ibexa\HttpCache\RepositoryTagPrefix
         # Use config resolver to be able to lazy load reading SA setting "repository" to avoid scope change issues
-        arguments: ['@ibexa.config.resolver', '%ezpublish.repositories%']
+        arguments: ['@ibexa.config.resolver', '%ibexa.repositories%']
 
     fos_http_cache.proxy_client.varnish:
         class: Ibexa\HttpCache\ProxyClient\Varnish


### PR DESCRIPTION
| Question                                  | Answer
| ---------------------------------------- | ------------------
| **JIRA issue**                          | [IBX-1696](https://issues.ibexa.co/browse/IBX-1696)
| **Type**                                   | feature
| **Target Ibexa version** | `v4.0`
| **BC breaks**                          | yes, requires ibexa/compatibility-layer#31

Rebranded service container parameter names and Ibexa Config Resolver namespaces to follow unified pattern

### TODO

- [ ] Run regressions
- [ ] Test manually
