### PR TITLE
Fixed no_vary route name after rebranding

### DIFF
--- a/src/bundle/Resources/config/default_settings.yml
+++ b/src/bundle/Resources/config/default_settings.yml
@@ -1,6 +1,6 @@
 parameters:
     ibexa.http_cache.store.root: "%kernel.cache_dir%/http_cache"
     ibexa.http_cache.invalidate_token.ttl: 86400
-    ibexa.http_cache.no_vary.routes: ['ezplatform.httpcache.invalidatetoken']
+    ibexa.http_cache.no_vary.routes: ['ibexa.http_cache.invalidate_token']
     ibexa.http_cache.translation_aware.enabled.default_value: false
     ibexa.http_cache.translation_aware.enabled: "%env(default:ibexa.http_cache.translation_aware.enabled.default_value:bool:HTTPCACHE_TRANSLATION_AWARE_ENABLED)%"


### PR DESCRIPTION
| Question           | Answer
| ------------------ | ------------------
| **JIRA issue**     | [IBX-5074](https://issues.ibexa.co/browse/IBX-5074)
| **Type**           | Bug
| **Target version** | 4.0
| **BC breaks**      | no
| **Doc needed**     | no

With the renaming from "ezplatform" to "ibexa", the "ibexa.http_cache.no_vary.routes" value was not fixed. Without this fix, all responses get Vary: cookie,authorization.