### PR TITLE
[CI] Fixed invalid branch for 4.3 REST tests

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -73,4 +73,4 @@ jobs:
 
   integration-tests:
       name: "REST integration tests"
-      uses: ibexa/rest/.github/workflows/integration-tests-callable.yaml@main
+      uses: ibexa/rest/.github/workflows/integration-tests-callable.yaml@4.3


### PR DESCRIPTION
4.2 for reference:
https://github.com/ibexa/http-cache/blob/4.2/.github/workflows/ci.yaml#L76

This change should be reverted in main