### PR TITLE
InvalidateTokenController: inline @internal

### DIFF
--- a/src/bundle/Controller/InvalidateTokenController.php
+++ b/src/bundle/Controller/InvalidateTokenController.php
@@ -38,7 +38,7 @@ class InvalidateTokenController
      * @param int $ttl
      * @param \FOS\HttpCache\ResponseTagger $tagHandler
      *
-     * @internal param string $invalidatetoken
+     * {@internal param string $invalidatetoken}
      */
     public function __construct(ConfigResolverInterface $configResolver, $ttl, ResponseTagger $tagHandler)
     {


### PR DESCRIPTION
| Question           | Answer
| ------------------ | ------------------
| **JIRA issue**     | [IBX-4929](https://issues.ibexa.co/browse/IBX-4929)
| **Type**           | Misc
| **Target version** | main
| **BC breaks**      | no
| **Doc needed**     | no

The constructor was tagged as "internal" with the reason "param string $invalidatetoken", excluding it from the phpDoc. The description make the tag looks like an old `@param` meant to be hidden.
Move it to an internal comment to stop excluding the constructor method.

https://docs.phpdoc.org/3.3/guide/references/phpdoc/tags/internal.html

**TODO**:
- [ ] Implement feature / fix a bug.
- [ ] Implement tests + specs and passing (`$ composer test`)
- [ ] Fix new code according to Coding Standards (`$ composer fix-cs`).
- [ ] Ask for Code Review.
