### PR TITLE
IBX-4929: Fix PhpDoc

### DIFF
--- a/src/contracts/Handler/ContentTagInterface.php
+++ b/src/contracts/Handler/ContentTagInterface.php
@@ -6,9 +6,6 @@
  */
 namespace Ibexa\Contracts\HttpCache\Handler;
 
-/**
- * @since 1.13 eZ Platform 1.13 (ezplatform-http-cache 0.9.3)
- */
 interface ContentTagInterface
 {
     public const CONTENT_PREFIX = 'c';

--- a/src/contracts/Handler/ContentTagInterface.php
+++ b/src/contracts/Handler/ContentTagInterface.php
@@ -7,7 +7,7 @@
 namespace Ibexa\Contracts\HttpCache\Handler;
 
 /**
- * @since v0.9.3
+ * @since 1.13 eZ Platform 1.13 (ezplatform-http-cache 0.9.3)
  */
 interface ContentTagInterface
 {


### PR DESCRIPTION
| Question           | Answer
| ------------------ | ------------------
| **JIRA issue**     | [IBX-4929](https://issues.ibexa.co/browse/IBX-4929)
| **Type**           | Bug
| **Target version** | 4.5
| **BC breaks**      | no
| **Doc needed**     | no

`Tag "since" with body "@since v0.9.3" has error`
- ~~Fix [`@since`](https://docs.phpdoc.org/3.3/guide/references/phpdoc/tags/since.html#since) usage (see https://github.com/ibexa/core/pull/226 for more)~~
- Remove the buggy tag

**TODO**:
- [ ] Implement feature / fix a bug.
- [ ] Implement tests + specs and passing (`$ composer test`)
- [ ] Fix new code according to Coding Standards (`$ composer fix-cs`).
- [ ] Ask for Code Review.
