### PR TITLE
Fixed deprecated KernelEvent::isMasterRequest call

### DIFF
--- a/src/lib/EventSubscriber/RequestEventSubscriber.php
+++ b/src/lib/EventSubscriber/RequestEventSubscriber.php
@@ -33,7 +33,7 @@ final class RequestEventSubscriber implements EventSubscriberInterface
 
     public function onKernelRequestForward(RequestEvent $event): void
     {
-        if ($event->isMasterRequest()) {
+        if ($event->isMainRequest()) {
             $request = $event->getRequest();
 
             if (


### PR DESCRIPTION
| Question                                  | Answer |
| ---------------------------------------- | ------------------ |
| **JIRA issue**                          | - |
| **Type**                                   | improvement |
| **Target Ibexa version** | `v4.4` |
| **BC breaks**                          | no |

Fixed deprecated `\Symfony\Component\HttpKernel\Event\KernelEvent::isMasterRequest` call in `\Ibexa\PageBuilder\Event\Subscriber\InjectCrossOriginHelperSubscriber::onResponse`

```
[Application] Apr 10 09:02:28 |INFO   | DEPREC User Deprecated: Since symfony/http-kernel 5.3: "Symfony\Component\HttpKernel\Event\KernelEvent::isMasterRequest()" is deprecated, use "isMainRequest()" instead. 
```

<!-- Replace this comment with Pull Request description -->

#### Checklist:
- [X] Provided PR description.
- [X] Tested the solution manually.
- [ ] Provided automated test coverage.
- [X] Checked that target branch is set correctly (main for features, the oldest supported for bugs).
- [X] Ran PHP CS Fixer for new PHP code (use `$ composer fix-cs`).
- [ ] Asked for a review (ping for example `@ibexa/php-dev` for back-end changes and/or `@ibexa/javascript-dev` for front-end changes).
