### PR TITLE
IBX-8119: Upgraded minimum PHP version to 8.3

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -10,13 +10,13 @@ on:
 jobs:
   cs_fix:
     name: Run code style check
-    runs-on: "ubuntu-20.04"
+    runs-on: "ubuntu-22.04"
     strategy:
       matrix:
         php:
-          - '8.0'
+          - '8.3'
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
 
       - name: Setup PHP Action
         uses: shivammathur/setup-php@v2
@@ -26,31 +26,26 @@ jobs:
           extensions: 'pdo_sqlite, gd'
           tools: cs2pr
 
-      - uses: "ramsey/composer-install@v1"
+      - uses: ramsey/composer-install@v3
         with:
-          dependency-versions: "highest"
+          dependency-versions: highest
 
       - name: Run code style check
         run: composer run-script check-cs -- --format=checkstyle | cs2pr
 
   tests:
     name: Tests
-    runs-on: "ubuntu-20.04"
+    runs-on: "ubuntu-22.04"
     timeout-minutes: 10
 
     strategy:
       fail-fast: false
       matrix:
         php:
-          - '7.4'
-          - '8.0'
-        composer_options: [ "" ]
-        include:
-            - php: '8.1'
-              composer_options: "--ignore-platform-req php"
+          - '8.3'
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
 
       - name: Setup PHP Action
         uses: shivammathur/setup-php@v2
@@ -60,10 +55,9 @@ jobs:
           extensions: pdo_sqlite, gd
           tools: cs2pr
 
-      - uses: "ramsey/composer-install@v1"
+      - uses: ramsey/composer-install@v3
         with:
-          dependency-versions: "highest"
-          composer-options: "${{ matrix.composer_options }}"
+          dependency-versions: highest
 
       - name: Setup problem matchers for PHPUnit
         run: echo "::add-matcher::${{ runner.tool_cache }}/phpunit.json"

--- a/composer.json
+++ b/composer.json
@@ -13,30 +13,30 @@
         }
     ],
     "require": {
-        "php": "^7.4 || ^8.0",
-        "ibexa/core": "~5.0.x-dev",
-        "ibexa/rest": "~5.0.0@dev",
-        "friendsofsymfony/http-cache-bundle": "^2.8",
+        "php": " >=8.3",
         "friendsofsymfony/http-cache": "^2.9",
-        "symfony/http-foundation": "^5.0",
-        "symfony/http-kernel": "^5.0",
+        "friendsofsymfony/http-cache-bundle": "^2.8",
+        "ibexa/core": "~5.0.x-dev",
+        "ibexa/rest": "~5.0.x-dev",
+        "php-http/curl-client": "^2.1",
+        "psr/http-client": "^1.0",
+        "symfony/config": "^5.0",
         "symfony/dependency-injection": "^5.0",
         "symfony/event-dispatcher": "^5.0",
+        "symfony/http-foundation": "^5.0",
+        "symfony/http-kernel": "^5.0",
         "symfony/routing": "^5.0",
         "symfony/yaml": "^5.0",
-        "symfony/config": "^5.0",
-        "psr/http-client": "^1.0",
-        "php-http/curl-client": "^2.1",
         "toflar/psr6-symfony-http-cache-store": "^2.2 || ^3.0"
     },
     "require-dev": {
+        "friendsofphp/php-cs-fixer": "^3.0",
         "ibexa/ci-scripts": "^0.2@dev",
-        "ibexa/doctrine-schema": "~5.0.0@dev",
-        "phpunit/phpunit": "^8.5",
+        "ibexa/code-style": "^1.0",
+        "ibexa/doctrine-schema": "~5.0.x-dev",
         "matthiasnoback/symfony-dependency-injection-test": "^4.3",
         "phpspec/phpspec": "^7.1",
-        "ibexa/code-style": "^1.0",
-        "friendsofphp/php-cs-fixer": "^3.0",
+        "phpunit/phpunit": "^8.5",
         "symfony/phpunit-bridge": "^5.1"
     },
     "autoload": {
@@ -68,5 +68,8 @@
         "branch-alias": {
             "dev-main": "5.0.x-dev"
         }
+    },
+    "config": {
+        "sort-packages": true
     }
 }


### PR DESCRIPTION
| :ticket: Issue | IBX-8119 |
|----------------|-----------|

#### Description:

This PR bumps the minimum required version of PHP to 8.3.
`>=8.3` version constraint is set with expectation of compatibility with version PHP 9.

Additionally, this PR:
 * enforces sorting of packages within `require` and `require-dev` sections of composer.json file
 * replaces `~5.0.0@dev` declarations with their more development friendly `~5.0.x-dev`.
 * adjusts github workflows to match new PHP version
 * updates GH action versions

#### For QA:
<!-- Optional. Replace this comment with any necessary information needed by QA to test this Pull Request -->

#### Documentation:
<!-- Optional. Replace this comment with details helpful for writing the doc: overview, code snippets for extensibility etc. -->


<!--
Before you click submit:
    - Test the solution manually
    - Provide automated test coverage
    - Confirm that target branch is set correctly
    - Run PHP CS Fixer for new PHP code (use $ composer fix-cs)
    - Run ESLint and Prettier for new JS/SCSS code (use $ yarn fix)
    - Ask for a review (ping @ibexa/php-dev or @ibexa/javascript-dev depending on the changes)
-->
