### PR TITLE
IBX-8139: Dropped class_alias BC layer statements from all classes

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -42,15 +42,13 @@
         "psr-4": {
             "Ibexa\\HttpCache\\": "src/lib/",
             "Ibexa\\Bundle\\HttpCache\\": "src/bundle/",
-            "Ibexa\\Contracts\\HttpCache\\": "src/contracts/",
-            "EzSystems\\PlatformHttpCacheBundle\\": "src/bundle/"
+            "Ibexa\\Contracts\\HttpCache\\": "src/contracts/"
         }
     },
     "autoload-dev": {
         "psr-4": {
             "Ibexa\\Tests\\HttpCache\\": "tests/lib/",
-            "Ibexa\\Tests\\Bundle\\HttpCache\\": "tests/bundle/",
-            "EzSystems\\PlatformHttpCacheBundle\\Tests\\": "tests"
+            "Ibexa\\Tests\\Bundle\\HttpCache\\": "tests/bundle/"
         }
     },
     "scripts": {

--- a/features/setup/symfonyCache.feature
+++ b/features/setup/symfonyCache.feature
@@ -21,7 +21,7 @@ index 9982c21..03ac40a 100644
  <?php
  
  use App\Kernel;
-+use EzSystems\PlatformHttpCacheBundle\AppCache;
++use Ibexa\Bundle\HttpCache\AppCache;
 +use Symfony\Component\HttpFoundation\Request;
  
  require_once dirname(__DIR__).'/vendor/autoload_runtime.php';

--- a/src/bundle/AppCache.php
+++ b/src/bundle/AppCache.php
@@ -116,5 +116,3 @@ class AppCache extends HttpCache implements CacheInvalidation
         }
     }
 }
-
-class_alias(AppCache::class, 'EzSystems\PlatformHttpCacheBundle\AppCache');

--- a/src/bundle/Controller/InvalidateTokenController.php
+++ b/src/bundle/Controller/InvalidateTokenController.php
@@ -80,5 +80,3 @@ class InvalidateTokenController
         return $response;
     }
 }
-
-class_alias(InvalidateTokenController::class, 'EzSystems\PlatformHttpCacheBundle\Controller\InvalidateTokenController');

--- a/src/bundle/DependencyInjection/Compiler/DriverPass.php
+++ b/src/bundle/DependencyInjection/Compiler/DriverPass.php
@@ -70,5 +70,3 @@ class DriverPass implements CompilerPassInterface
         return $configuredTagHandlerServiceId;
     }
 }
-
-class_alias(DriverPass::class, 'EzSystems\PlatformHttpCacheBundle\DependencyInjection\Compiler\DriverPass');

--- a/src/bundle/DependencyInjection/Compiler/KernelPass.php
+++ b/src/bundle/DependencyInjection/Compiler/KernelPass.php
@@ -93,5 +93,3 @@ class KernelPass implements CompilerPassInterface
         return strpos($id, 'ezpublish.http_cache.purger.') === 0;
     }
 }
-
-class_alias(KernelPass::class, 'EzSystems\PlatformHttpCacheBundle\DependencyInjection\Compiler\KernelPass');

--- a/src/bundle/DependencyInjection/Compiler/ResponseTaggersPass.php
+++ b/src/bundle/DependencyInjection/Compiler/ResponseTaggersPass.php
@@ -34,5 +34,3 @@ class ResponseTaggersPass implements CompilerPassInterface
         $dispatcher->replaceArgument(0, $taggers);
     }
 }
-
-class_alias(ResponseTaggersPass::class, 'EzSystems\PlatformHttpCacheBundle\DependencyInjection\Compiler\ResponseTaggersPass');

--- a/src/bundle/DependencyInjection/Compiler/VarnishCachePass.php
+++ b/src/bundle/DependencyInjection/Compiler/VarnishCachePass.php
@@ -40,5 +40,3 @@ class VarnishCachePass implements CompilerPassInterface
         );
     }
 }
-
-class_alias(VarnishCachePass::class, 'EzSystems\PlatformHttpCacheBundle\DependencyInjection\Compiler\VarnishCachePass');

--- a/src/bundle/DependencyInjection/ConfigResolver/HttpCacheConfigParser.php
+++ b/src/bundle/DependencyInjection/ConfigResolver/HttpCacheConfigParser.php
@@ -97,5 +97,3 @@ class HttpCacheConfigParser implements ParserInterface
         return $this->httpCacheExtension->getExtraConfigParsers();
     }
 }
-
-class_alias(HttpCacheConfigParser::class, 'EzSystems\PlatformHttpCacheBundle\DependencyInjection\ConfigResolver\HttpCacheConfigParser');

--- a/src/bundle/DependencyInjection/Configuration.php
+++ b/src/bundle/DependencyInjection/Configuration.php
@@ -25,5 +25,3 @@ class Configuration implements ConfigurationInterface
         return new TreeBuilder('ibexa_http_cache');
     }
 }
-
-class_alias(Configuration::class, 'EzSystems\PlatformHttpCacheBundle\DependencyInjection\Configuration');

--- a/src/bundle/DependencyInjection/IbexaHttpCacheExtension.php
+++ b/src/bundle/DependencyInjection/IbexaHttpCacheExtension.php
@@ -77,5 +77,3 @@ class IbexaHttpCacheExtension extends Extension implements PrependExtensionInter
         return $this->extraConfigParsers;
     }
 }
-
-class_alias(IbexaHttpCacheExtension::class, 'EzSystems\PlatformHttpCacheBundle\DependencyInjection\EzPlatformHttpCacheExtension');

--- a/src/bundle/IbexaHttpCacheBundle.php
+++ b/src/bundle/IbexaHttpCacheBundle.php
@@ -67,5 +67,3 @@ class IbexaHttpCacheBundle extends Bundle
         );
     }
 }
-
-class_alias(IbexaHttpCacheBundle::class, 'EzSystems\PlatformHttpCacheBundle\EzSystemsPlatformHttpCacheBundle');

--- a/src/contracts/Handler/ContentTagInterface.php
+++ b/src/contracts/Handler/ContentTagInterface.php
@@ -83,5 +83,3 @@ interface ContentTagInterface
      */
     public function addContentTypeTags(array $contentTypeIds);
 }
-
-class_alias(ContentTagInterface::class, 'EzSystems\PlatformHttpCacheBundle\Handler\ContentTagInterface');

--- a/src/contracts/PurgeClient/PurgeClientInterface.php
+++ b/src/contracts/PurgeClient/PurgeClientInterface.php
@@ -28,5 +28,3 @@ interface PurgeClientInterface
      */
     public function purgeAll(): void;
 }
-
-class_alias(PurgeClientInterface::class, 'EzSystems\PlatformHttpCacheBundle\PurgeClient\PurgeClientInterface');

--- a/src/contracts/ResponseTagger/ResponseTagger.php
+++ b/src/contracts/ResponseTagger/ResponseTagger.php
@@ -19,5 +19,3 @@ interface ResponseTagger
      */
     public function tag($value);
 }
-
-class_alias(ResponseTagger::class, 'EzSystems\PlatformHttpCacheBundle\ResponseTagger\ResponseTagger');

--- a/src/lib/ContextProvider/RoleIdentify.php
+++ b/src/lib/ContextProvider/RoleIdentify.php
@@ -78,5 +78,3 @@ class RoleIdentify implements ContextProvider
         $context->addParameter('roleLimitationList', $limitationValues);
     }
 }
-
-class_alias(RoleIdentify::class, 'EzSystems\PlatformHttpCacheBundle\ContextProvider\RoleIdentify');

--- a/src/lib/EventListener/ConditionallyRemoveVaryHeaderListener.php
+++ b/src/lib/EventListener/ConditionallyRemoveVaryHeaderListener.php
@@ -79,5 +79,3 @@ class ConditionallyRemoveVaryHeaderListener implements EventSubscriberInterface
         ];
     }
 }
-
-class_alias(ConditionallyRemoveVaryHeaderListener::class, 'EzSystems\PlatformHttpCacheBundle\EventListener\ConditionallyRemoveVaryHeaderListener');

--- a/src/lib/EventSubscriber/CachePurge/AbstractSubscriber.php
+++ b/src/lib/EventSubscriber/CachePurge/AbstractSubscriber.php
@@ -93,5 +93,3 @@ abstract class AbstractSubscriber implements EventSubscriberInterface
         return $tags;
     }
 }
-
-class_alias(AbstractSubscriber::class, 'EzSystems\PlatformHttpCacheBundle\EventSubscriber\CachePurge\AbstractSubscriber');

--- a/src/lib/EventSubscriber/CachePurge/ContentEventsSubscriber.php
+++ b/src/lib/EventSubscriber/CachePurge/ContentEventsSubscriber.php
@@ -194,5 +194,3 @@ final class ContentEventsSubscriber extends AbstractSubscriber
         });
     }
 }
-
-class_alias(ContentEventsSubscriber::class, 'EzSystems\PlatformHttpCacheBundle\EventSubscriber\CachePurge\ContentEventsSubscriber');

--- a/src/lib/EventSubscriber/CachePurge/ContentTypeEventsSubscriber.php
+++ b/src/lib/EventSubscriber/CachePurge/ContentTypeEventsSubscriber.php
@@ -89,5 +89,3 @@ final class ContentTypeEventsSubscriber extends AbstractSubscriber
         ]);
     }
 }
-
-class_alias(ContentTypeEventsSubscriber::class, 'EzSystems\PlatformHttpCacheBundle\EventSubscriber\CachePurge\ContentTypeEventsSubscriber');

--- a/src/lib/EventSubscriber/CachePurge/LocationEventsSubscriber.php
+++ b/src/lib/EventSubscriber/CachePurge/LocationEventsSubscriber.php
@@ -167,5 +167,3 @@ final class LocationEventsSubscriber extends AbstractSubscriber
         $this->purgeClient->purge($tags);
     }
 }
-
-class_alias(LocationEventsSubscriber::class, 'EzSystems\PlatformHttpCacheBundle\EventSubscriber\CachePurge\LocationEventsSubscriber');

--- a/src/lib/EventSubscriber/CachePurge/ObjectStateEventsSubscriber.php
+++ b/src/lib/EventSubscriber/CachePurge/ObjectStateEventsSubscriber.php
@@ -31,5 +31,3 @@ final class ObjectStateEventsSubscriber extends AbstractSubscriber
         $this->purgeClient->purge($tags);
     }
 }
-
-class_alias(ObjectStateEventsSubscriber::class, 'EzSystems\PlatformHttpCacheBundle\EventSubscriber\CachePurge\ObjectStateEventsSubscriber');

--- a/src/lib/EventSubscriber/CachePurge/RoleEventsSubscriber.php
+++ b/src/lib/EventSubscriber/CachePurge/RoleEventsSubscriber.php
@@ -35,5 +35,3 @@ final class RoleEventsSubscriber extends AbstractSubscriber
         ]);
     }
 }
-
-class_alias(RoleEventsSubscriber::class, 'EzSystems\PlatformHttpCacheBundle\EventSubscriber\CachePurge\RoleEventsSubscriber');

--- a/src/lib/EventSubscriber/CachePurge/SectionEventsSubscriber.php
+++ b/src/lib/EventSubscriber/CachePurge/SectionEventsSubscriber.php
@@ -73,5 +73,3 @@ final class SectionEventsSubscriber extends AbstractSubscriber
         $this->purgeClient->purge($tags);
     }
 }
-
-class_alias(SectionEventsSubscriber::class, 'EzSystems\PlatformHttpCacheBundle\EventSubscriber\CachePurge\SectionEventsSubscriber');

--- a/src/lib/EventSubscriber/CachePurge/TranslationEventsSubscriber.php
+++ b/src/lib/EventSubscriber/CachePurge/TranslationEventsSubscriber.php
@@ -31,5 +31,3 @@ final class TranslationEventsSubscriber extends AbstractSubscriber
         $this->purgeClient->purge($tags);
     }
 }
-
-class_alias(TranslationEventsSubscriber::class, 'EzSystems\PlatformHttpCacheBundle\EventSubscriber\CachePurge\TranslationEventsSubscriber');

--- a/src/lib/EventSubscriber/CachePurge/TrashEventsSubscriber.php
+++ b/src/lib/EventSubscriber/CachePurge/TrashEventsSubscriber.php
@@ -49,5 +49,3 @@ final class TrashEventsSubscriber extends AbstractSubscriber
         $this->purgeClient->purge($tags);
     }
 }
-
-class_alias(TrashEventsSubscriber::class, 'EzSystems\PlatformHttpCacheBundle\EventSubscriber\CachePurge\TrashEventsSubscriber');

--- a/src/lib/EventSubscriber/CachePurge/UrlEventsSubscriber.php
+++ b/src/lib/EventSubscriber/CachePurge/UrlEventsSubscriber.php
@@ -30,5 +30,3 @@ final class UrlEventsSubscriber extends AbstractSubscriber
         }
     }
 }
-
-class_alias(UrlEventsSubscriber::class, 'EzSystems\PlatformHttpCacheBundle\EventSubscriber\CachePurge\UrlEventsSubscriber');

--- a/src/lib/EventSubscriber/CachePurge/UserEventsSubscriber.php
+++ b/src/lib/EventSubscriber/CachePurge/UserEventsSubscriber.php
@@ -102,5 +102,3 @@ final class UserEventsSubscriber extends AbstractSubscriber
         $this->purgeClient->purge($tags);
     }
 }
-
-class_alias(UserEventsSubscriber::class, 'EzSystems\PlatformHttpCacheBundle\EventSubscriber\CachePurge\UserEventsSubscriber');

--- a/src/lib/EventSubscriber/HiddenLocationExceptionSubscriber.php
+++ b/src/lib/EventSubscriber/HiddenLocationExceptionSubscriber.php
@@ -49,5 +49,3 @@ class HiddenLocationExceptionSubscriber implements EventSubscriberInterface
         $this->contentInfoTagger->tag($location->getContentInfo());
     }
 }
-
-class_alias(HiddenLocationExceptionSubscriber::class, 'EzSystems\PlatformHttpCacheBundle\EventSubscriber\HiddenLocationExceptionSubscriber');

--- a/src/lib/EventSubscriber/HttpCacheResponseSubscriber.php
+++ b/src/lib/EventSubscriber/HttpCacheResponseSubscriber.php
@@ -55,5 +55,3 @@ class HttpCacheResponseSubscriber implements EventSubscriberInterface
         // NB!: FOSHTTPCacheBundle is taking care about writing the tags in own tag handler happening with priority 0
     }
 }
-
-class_alias(HttpCacheResponseSubscriber::class, 'EzSystems\PlatformHttpCacheBundle\EventSubscriber\HttpCacheResponseSubscriber');

--- a/src/lib/EventSubscriber/RequestEventSubscriber.php
+++ b/src/lib/EventSubscriber/RequestEventSubscriber.php
@@ -48,5 +48,3 @@ final class RequestEventSubscriber implements EventSubscriberInterface
         }
     }
 }
-
-class_alias(RequestEventSubscriber::class, 'EzSystems\PlatformHttpCacheBundle\EventSubscriber\RequestEventSubscriber');

--- a/src/lib/EventSubscriber/RestKernelViewSubscriber.php
+++ b/src/lib/EventSubscriber/RestKernelViewSubscriber.php
@@ -109,5 +109,3 @@ class RestKernelViewSubscriber implements EventSubscriberInterface
         return $tags;
     }
 }
-
-class_alias(RestKernelViewSubscriber::class, 'EzSystems\PlatformHttpCacheBundle\EventSubscriber\RestKernelViewSubscriber');

--- a/src/lib/EventSubscriber/UserContextSiteAccessMatchSubscriber.php
+++ b/src/lib/EventSubscriber/UserContextSiteAccessMatchSubscriber.php
@@ -50,5 +50,3 @@ class UserContextSiteAccessMatchSubscriber implements EventSubscriberInterface
         $this->innerSubscriber->onKernelRequest($event);
     }
 }
-
-class_alias(UserContextSiteAccessMatchSubscriber::class, 'EzSystems\PlatformHttpCacheBundle\EventSubscriber\UserContextSiteAccessMatchSubscriber');

--- a/src/lib/EventSubscriber/UserContextSubscriber.php
+++ b/src/lib/EventSubscriber/UserContextSubscriber.php
@@ -68,5 +68,3 @@ class UserContextSubscriber implements EventSubscriberInterface
         $response->headers->set($this->tagHeader, $this->prefixService->getRepositoryPrefix() . 'ez-user-context-hash');
     }
 }
-
-class_alias(UserContextSubscriber::class, 'EzSystems\PlatformHttpCacheBundle\EventSubscriber\UserContextSubscriber');

--- a/src/lib/EventSubscriber/XLocationIdResponseSubscriber.php
+++ b/src/lib/EventSubscriber/XLocationIdResponseSubscriber.php
@@ -90,5 +90,3 @@ class XLocationIdResponseSubscriber implements EventSubscriberInterface
         $response->headers->remove(static::LOCATION_ID_HEADER);
     }
 }
-
-class_alias(XLocationIdResponseSubscriber::class, 'EzSystems\PlatformHttpCacheBundle\EventSubscriber\XLocationIdResponseSubscriber');

--- a/src/lib/Handler/TagHandler.php
+++ b/src/lib/Handler/TagHandler.php
@@ -191,5 +191,3 @@ class TagHandler extends SymfonyResponseTagger implements ContentTagInterface
         }, $contentTypeIds));
     }
 }
-
-class_alias(TagHandler::class, 'EzSystems\PlatformHttpCacheBundle\Handler\TagHandler');

--- a/src/lib/Proxy/UserContextListener.php
+++ b/src/lib/Proxy/UserContextListener.php
@@ -24,5 +24,3 @@ class UserContextListener extends BaseUserContextListener
         $hashLookupRequest->attributes->set('_ez_original_request', $originalRequest);
     }
 }
-
-class_alias(UserContextListener::class, 'EzSystems\PlatformHttpCacheBundle\Proxy\UserContextListener');

--- a/src/lib/ProxyClient/HttpDispatcherFactory.php
+++ b/src/lib/ProxyClient/HttpDispatcherFactory.php
@@ -62,5 +62,3 @@ class HttpDispatcherFactory
         return new $this->httpDispatcherClass($allServers, $baseUrl);
     }
 }
-
-class_alias(HttpDispatcherFactory::class, 'EzSystems\PlatformHttpCacheBundle\ProxyClient\HttpDispatcherFactory');

--- a/src/lib/ProxyClient/Varnish.php
+++ b/src/lib/ProxyClient/Varnish.php
@@ -57,5 +57,3 @@ final class Varnish extends FosVarnish implements BanCapable, PurgeCapable, Refr
         parent::queueRequest($method, $url, $this->fetchAndMergeAuthHeaders($headers), $body);
     }
 }
-
-class_alias(Varnish::class, 'EzSystems\PlatformHttpCacheBundle\ProxyClient\Varnish');

--- a/src/lib/PurgeClient/LocalPurgeClient.php
+++ b/src/lib/PurgeClient/LocalPurgeClient.php
@@ -34,5 +34,3 @@ class LocalPurgeClient implements PurgeClientInterface
         $this->cacheStore->invalidateTags(['ez-all']);
     }
 }
-
-class_alias(LocalPurgeClient::class, 'EzSystems\PlatformHttpCacheBundle\PurgeClient\LocalPurgeClient');

--- a/src/lib/PurgeClient/RepositoryPrefixDecorator.php
+++ b/src/lib/PurgeClient/RepositoryPrefixDecorator.php
@@ -53,5 +53,3 @@ class RepositoryPrefixDecorator implements PurgeClientInterface
         $this->purgeClient->purgeAll();
     }
 }
-
-class_alias(RepositoryPrefixDecorator::class, 'EzSystems\PlatformHttpCacheBundle\PurgeClient\RepositoryPrefixDecorator');

--- a/src/lib/PurgeClient/VarnishPurgeClient.php
+++ b/src/lib/PurgeClient/VarnishPurgeClient.php
@@ -34,5 +34,3 @@ class VarnishPurgeClient implements PurgeClientInterface
         $this->cacheManager->invalidateTags(['ez-all']);
     }
 }
-
-class_alias(VarnishPurgeClient::class, 'EzSystems\PlatformHttpCacheBundle\PurgeClient\VarnishPurgeClient');

--- a/src/lib/RepositoryTagPrefix.php
+++ b/src/lib/RepositoryTagPrefix.php
@@ -54,5 +54,3 @@ class RepositoryTagPrefix
         return (string) (empty($repositoryIdentifier) ? '' : $this->repositoryMap[$repositoryIdentifier]);
     }
 }
-
-class_alias(RepositoryTagPrefix::class, 'EzSystems\PlatformHttpCacheBundle\RepositoryTagPrefix');

--- a/src/lib/ResponseConfigurator/ConfigurableResponseCacheConfigurator.php
+++ b/src/lib/ResponseConfigurator/ConfigurableResponseCacheConfigurator.php
@@ -57,5 +57,3 @@ class ConfigurableResponseCacheConfigurator implements ResponseCacheConfigurator
         return (int)$this->configResolver->getParameter('content.default_ttl');
     }
 }
-
-class_alias(ConfigurableResponseCacheConfigurator::class, 'EzSystems\PlatformHttpCacheBundle\ResponseConfigurator\ConfigurableResponseCacheConfigurator');

--- a/src/lib/ResponseConfigurator/ResponseCacheConfigurator.php
+++ b/src/lib/ResponseConfigurator/ResponseCacheConfigurator.php
@@ -32,5 +32,3 @@ interface ResponseCacheConfigurator
      */
     public function setSharedMaxAge(Response $response);
 }
-
-class_alias(ResponseCacheConfigurator::class, 'EzSystems\PlatformHttpCacheBundle\ResponseConfigurator\ResponseCacheConfigurator');

--- a/src/lib/ResponseTagger/Delegator/ContentValueViewTagger.php
+++ b/src/lib/ResponseTagger/Delegator/ContentValueViewTagger.php
@@ -33,5 +33,3 @@ class ContentValueViewTagger implements ResponseTagger
         $this->contentInfoTagger->tag($contentInfo);
     }
 }
-
-class_alias(ContentValueViewTagger::class, 'EzSystems\PlatformHttpCacheBundle\ResponseTagger\Delegator\ContentValueViewTagger');

--- a/src/lib/ResponseTagger/Delegator/DispatcherTagger.php
+++ b/src/lib/ResponseTagger/Delegator/DispatcherTagger.php
@@ -31,5 +31,3 @@ class DispatcherTagger implements ResponseTagger
         }
     }
 }
-
-class_alias(DispatcherTagger::class, 'EzSystems\PlatformHttpCacheBundle\ResponseTagger\Delegator\DispatcherTagger');

--- a/src/lib/ResponseTagger/Delegator/LocationValueViewTagger.php
+++ b/src/lib/ResponseTagger/Delegator/LocationValueViewTagger.php
@@ -32,5 +32,3 @@ class LocationValueViewTagger implements ResponseTagger
         $this->locationTagger->tag($location);
     }
 }
-
-class_alias(LocationValueViewTagger::class, 'EzSystems\PlatformHttpCacheBundle\ResponseTagger\Delegator\LocationValueViewTagger');

--- a/src/lib/ResponseTagger/Value/AbstractValueTagger.php
+++ b/src/lib/ResponseTagger/Value/AbstractValueTagger.php
@@ -20,5 +20,3 @@ abstract class AbstractValueTagger implements ResponseTagger
         $this->responseTagger = $responseTagger;
     }
 }
-
-class_alias(AbstractValueTagger::class, 'EzSystems\PlatformHttpCacheBundle\ResponseTagger\Value\AbstractValueTagger');

--- a/src/lib/ResponseTagger/Value/ContentInfoTagger.php
+++ b/src/lib/ResponseTagger/Value/ContentInfoTagger.php
@@ -28,5 +28,3 @@ class ContentInfoTagger extends AbstractValueTagger
         }
     }
 }
-
-class_alias(ContentInfoTagger::class, 'EzSystems\PlatformHttpCacheBundle\ResponseTagger\Value\ContentInfoTagger');

--- a/src/lib/ResponseTagger/Value/LocationTagger.php
+++ b/src/lib/ResponseTagger/Value/LocationTagger.php
@@ -33,5 +33,3 @@ class LocationTagger extends AbstractValueTagger
         );
     }
 }
-
-class_alias(LocationTagger::class, 'EzSystems\PlatformHttpCacheBundle\ResponseTagger\Value\LocationTagger');

--- a/src/lib/Twig/ContentTaggingExtension.php
+++ b/src/lib/Twig/ContentTaggingExtension.php
@@ -121,5 +121,3 @@ class ContentTaggingExtension extends AbstractExtension
         $this->contentTagHandler->addRelationLocationTags((array)$locationIds);
     }
 }
-
-class_alias(ContentTaggingExtension::class, 'EzSystems\PlatformHttpCacheBundle\Twig\ContentTaggingExtension');

--- a/tests/lib/ContextProvider/RoleIdentifyTest.php
+++ b/tests/lib/ContextProvider/RoleIdentifyTest.php
@@ -192,5 +192,3 @@ class RoleIdentifyTest extends TestCase
             ->getMockForAbstractClass();
     }
 }
-
-class_alias(RoleIdentifyTest::class, 'EzSystems\PlatformHttpCacheBundle\Tests\ContextProvider\RoleIdentifyTest');

--- a/tests/lib/PurgeClient/LocalPurgeClientTest.php
+++ b/tests/lib/PurgeClient/LocalPurgeClientTest.php
@@ -40,5 +40,3 @@ class LocalPurgeClientTest extends TestCase
         $purgeClient->purge($keys);
     }
 }
-
-class_alias(LocalPurgeClientTest::class, 'EzSystems\PlatformHttpCacheBundle\Tests\PurgeClient\LocalPurgeClientTest');

--- a/tests/lib/PurgeClient/RepositoryPrefixDecoratorTest.php
+++ b/tests/lib/PurgeClient/RepositoryPrefixDecoratorTest.php
@@ -88,5 +88,3 @@ class RepositoryPrefixDecoratorTest extends TestCase
         $this->prefixDecorator->purgeAll();
     }
 }
-
-class_alias(RepositoryPrefixDecoratorTest::class, 'EzSystems\PlatformHttpCacheBundle\Tests\PurgeClient\RepositoryPrefixDecoratorTest');

--- a/tests/lib/PurgeClient/VarnishPurgeClientTest.php
+++ b/tests/lib/PurgeClient/VarnishPurgeClientTest.php
@@ -88,5 +88,3 @@ class VarnishPurgeClientTest extends TestCase
         $this->purgeClient->purgeAll();
     }
 }
-
-class_alias(VarnishPurgeClientTest::class, 'EzSystems\PlatformHttpCacheBundle\Tests\PurgeClient\VarnishPurgeClientTest');


### PR DESCRIPTION
| :ticket: Issue | IBX-8139 |
|----------------|-----------|

#### Description:

Dropped `class_alias` BC layer statements from all classes using https://github.com/ibexa/rector/pull/2

#### For QA:

No QA needed. Baseline for failing CI: #50 

#### Documentation:

Document that our BC layer has been dropped
