### PR TITLE
IBX-9513: Fixed obsolete `ibexa_content` Controller references

### DIFF
--- a/src/bundle/Resources/views/fields/content_fields.html.twig
+++ b/src/bundle/Resources/views/fields/content_fields.html.twig
@@ -10,7 +10,7 @@
                     {% if parameters.available[contentId] %}
                         {{ ibexa_http_cache_tag_relation_ids(contentId) }}
                         <li>
-                            {{ render( controller( "ibexa_content:viewAction", {'contentId': contentId, 'viewType': 'embed', 'layout': false} ) ) }}
+                            {{ render( controller( "ibexa_content::viewAction", {'contentId': contentId, 'viewType': 'embed', 'layout': false} ) ) }}
                         </li>
                     {% endif %}
                 {% endfor %}
@@ -24,7 +24,7 @@
         {% if not ibexa_field_is_empty(content, field) and parameters.available %}
             {{ ibexa_http_cache_tag_relation_ids(field.value.destinationContentId) }}
             <div {{ block('field_attributes') }}>
-                {{ render(controller('ibexa_content:embedAction', {
+                {{ render(controller('ibexa_content::embedAction', {
                     contentId: field.value.destinationContentId,
                     viewType: 'asset_image',
                     no_layout: true,
@@ -42,7 +42,7 @@
         {% if not ibexa_field_is_empty( content, field ) and parameters.available %}
             {{ ibexa_http_cache_tag_relation_ids(field.value.destinationContentId) }}
             <div {{ block( 'field_attributes' ) }}>
-                {{ render( controller( "ibexa_content:viewAction", {'contentId': field.value.destinationContentId, 'viewType': 'text_linked', 'layout': false} ) ) }}
+                {{ render( controller( "ibexa_content::viewAction", {'contentId': field.value.destinationContentId, 'viewType': 'text_linked', 'layout': false} ) ) }}
             </div>
         {% endif %}
     {% endapply %}


### PR DESCRIPTION
| :ticket: Issue | IBX-9513 |
|----------------|-----------|


#### Related PRs: 
- https://github.com/ibexa/core/pull/474
- https://github.com/ibexa/fieldtype-query/pull/35


#### Description:

Fixed single colon controller references, which seem to be no longer working in Symfony 6.

Note: we have behat failures for http cache fetatures and REST integration tests failures, which need to be handled separately.

#### For QA:

The bug might be reproducible in a similar form to the one from JIRA ticket, when using HTTP cache (e.g. Varnish). Not 100% sure however, just a guess. If so, affected field types:
* Relation
* Relation List
* Image Asset