### PR TITLE
[Twig] Removed usage of deprecated spaceless filter

### DIFF
--- a/src/bundle/Resources/views/fields/content_fields.html.twig
+++ b/src/bundle/Resources/views/fields/content_fields.html.twig
@@ -3,47 +3,41 @@
 {% extends "@IbexaCore/content_fields.html.twig" %}
 
 {% block ezobjectrelationlist_field %}
-    {% apply spaceless %}
-        {% if not ibexa_field_is_empty( content, field ) %}
-            <ul {{ block( 'field_attributes' ) }}>
-                {% for contentId in field.value.destinationContentIds %}
-                    {% if parameters.available[contentId] %}
-                        {{ ibexa_http_cache_tag_relation_ids(contentId) }}
-                        <li>
-                            {{ render( controller( "ibexa_content::viewAction", {'contentId': contentId, 'viewType': 'embed', 'layout': false} ) ) }}
-                        </li>
-                    {% endif %}
-                {% endfor %}
-            </ul>
-        {% endif %}
-    {% endapply %}
+    {% if not ibexa_field_is_empty( content, field ) %}
+        <ul {{ block( 'field_attributes' ) }}>
+            {% for contentId in field.value.destinationContentIds %}
+                {% if parameters.available[contentId] %}
+                    {{ ibexa_http_cache_tag_relation_ids(contentId) }}
+                    <li>
+                        {{ render( controller( "ibexa_content::viewAction", {'contentId': contentId, 'viewType': 'embed', 'layout': false} ) ) }}
+                    </li>
+                {% endif %}
+            {% endfor %}
+        </ul>
+    {% endif %}
 {% endblock %}
 
 {% block ezimageasset_field %}
-    {% apply spaceless %}
-        {% if not ibexa_field_is_empty(content, field) and parameters.available %}
-            {{ ibexa_http_cache_tag_relation_ids(field.value.destinationContentId) }}
-            <div {{ block('field_attributes') }}>
-                {{ render(controller('ibexa_content::embedAction', {
-                    contentId: field.value.destinationContentId,
-                    viewType: 'asset_image',
-                    no_layout: true,
-                    params: {
-                        parameters: parameters|default({'alias': 'original'})|merge({'alternativeText': field.value.alternativeText })
-                    }
-                }))}}
-            </div>
-        {% endif %}
-    {% endapply %}
+    {% if not ibexa_field_is_empty(content, field) and parameters.available %}
+        {{ ibexa_http_cache_tag_relation_ids(field.value.destinationContentId) }}
+        <div {{ block('field_attributes') }}>
+            {{ render(controller('ibexa_content::embedAction', {
+                contentId: field.value.destinationContentId,
+                viewType: 'asset_image',
+                no_layout: true,
+                params: {
+                    parameters: parameters|default({'alias': 'original'})|merge({'alternativeText': field.value.alternativeText })
+                }
+            }))}}
+        </div>
+    {% endif %}
 {% endblock %}
 
 {% block ezobjectrelation_field %}
-    {% apply spaceless %}
-        {% if not ibexa_field_is_empty( content, field ) and parameters.available %}
-            {{ ibexa_http_cache_tag_relation_ids(field.value.destinationContentId) }}
-            <div {{ block( 'field_attributes' ) }}>
-                {{ render( controller( "ibexa_content::viewAction", {'contentId': field.value.destinationContentId, 'viewType': 'text_linked', 'layout': false} ) ) }}
-            </div>
-        {% endif %}
-    {% endapply %}
+    {% if not ibexa_field_is_empty( content, field ) and parameters.available %}
+        {{ ibexa_http_cache_tag_relation_ids(field.value.destinationContentId) }}
+        <div {{ block( 'field_attributes' ) }}>
+            {{ render( controller( "ibexa_content::viewAction", {'contentId': field.value.destinationContentId, 'viewType': 'text_linked', 'layout': false} ) ) }}
+        </div>
+    {% endif %}
 {% endblock %}


### PR DESCRIPTION
| :ticket: Issue | N/A       |
|----------------|-----------|

<!-- 
#### Related PRs: 
- https://github.com/ibexa/core/pull/1
-->

#### Description:

> The spaceless filter is deprecated as of Twig 3.12 and will be removed in Twig 4.0.

See https://twig.symfony.com/doc/3.x/deprecated.html 

#### For QA:
Limitations and field types rendering.

#### Documentation:
N/A

<!-- 
Before you click submit:
    - Test the solution manually
    - Provide automated test coverage
    - Confirm that target branch is set correctly
    - Run PHP CS Fixer for new PHP code (use $ composer fix-cs)
    - Run ESLint and Prettier for new JS/SCSS code (use $ yarn fix)
    - Ask for a review (ping @ibexa/php-dev or @ibexa/javascript-dev depending on the changes) 
--> 
