### PR TITLE
Removed fos_http_cache.tags.annotations.enabled parameter from prepended configuration

### DIFF
--- a/src/bundle/Resources/config/prepend/fos_http_cache.yml
+++ b/src/bundle/Resources/config/prepend/fos_http_cache.yml
@@ -10,7 +10,3 @@ user_context:
     hash_cache_ttl: 600
     # NOTE: These are also defined/used in AppCache, in Varnish VCL, and Fastly VCL
     session_name_prefix: IBX_SESSION_ID
-
-tags:
-    annotations:
-        enabled: false


### PR DESCRIPTION
| :ticket: Issue | N/A       |
|----------------|-----------|

<!-- 
#### Related PRs: 
- https://github.com/ibexa/core/pull/1
-->

#### Description:

`fos_http_cache.tags.annotations.enabled` configuration option is not longer available in newest version of `friendsofsymfony/http-cache-bundle`. 

PR unblocks upgrade to Syfmony 7.

#### For QA:
Sanities.

#### Documentation:
N/A

<!-- 
Before you click submit:
    - Test the solution manually
    - Provide automated test coverage
    - Confirm that target branch is set correctly
    - For new features, confirm that you have suitable access control and injection prevention
    - Run PHP CS Fixer for new PHP code (use $ composer fix-cs)
    - Run ESLint and Prettier for new JS/SCSS code (use $ yarn fix)
    - Ask for a review (ping @ibexa/php-dev or @ibexa/javascript-dev depending on the changes) 
--> 
