### PR TITLE
IBX-9727: Added missing type hints

### DIFF
--- a/spec/EventSubscriber/HiddenLocationExceptionSubscriberSpec.php
+++ b/spec/EventSubscriber/HiddenLocationExceptionSubscriberSpec.php
@@ -23,7 +23,7 @@ class HiddenLocationExceptionSubscriberSpec extends ObjectBehavior
     public function let(
         LocationTagger $locationTagger,
         ContentInfoTagger $contentInfoTagger
-    ) {
+    ): void {
         $this->beConstructedWith($locationTagger, $contentInfoTagger);
     }
 
@@ -35,7 +35,7 @@ class HiddenLocationExceptionSubscriberSpec extends ObjectBehavior
         Location $location,
         ContentInfo $contentInfo,
         HiddenLocationException $exception
-    ) {
+    ): void {
         $exception->getLocation()->willReturn($location);
         $location->getContentInfo()->willReturn($contentInfo);
         $locationTagger->tag($location)->willReturn($locationTagger);
@@ -61,7 +61,7 @@ class HiddenLocationExceptionSubscriberSpec extends ObjectBehavior
         LocationTagger $locationTagger,
         ContentInfoTagger $contentInfoTagger,
         \Exception $exception
-    ) {
+    ): void {
         $event = new ExceptionEvent(
             $kernel->getWrappedObject(),
             $request->getWrappedObject(),

--- a/spec/EventSubscriber/HttpCacheResponseSubscriberSpec.php
+++ b/spec/EventSubscriber/HttpCacheResponseSubscriberSpec.php
@@ -26,7 +26,7 @@ class HttpCacheResponseSubscriberSpec extends ObjectBehavior
         ParameterBag $requestAttributes,
         ResponseCacheConfigurator $configurator,
         ResponseTagger $dispatcherTagger
-    ) {
+    ): void {
         $request->attributes = $requestAttributes;
 
         $this->beConstructedWith($configurator, $dispatcherTagger);
@@ -39,7 +39,7 @@ class HttpCacheResponseSubscriberSpec extends ObjectBehavior
         ResponseCacheConfigurator $configurator,
         ParameterBag $requestAttributes,
         View $nonCachableView
-    ) {
+    ): void {
         $requestAttributes->get('view')->willReturn($nonCachableView);
 
         $event = new ResponseEvent(
@@ -61,7 +61,7 @@ class HttpCacheResponseSubscriberSpec extends ObjectBehavior
         ResponseCacheConfigurator $configurator,
         CachableView $view,
         ParameterBag $requestAttributes
-    ) {
+    ): void {
         $requestAttributes->get('view')->willReturn($view);
         $view->isCacheEnabled()->willReturn(false);
 
@@ -85,7 +85,7 @@ class HttpCacheResponseSubscriberSpec extends ObjectBehavior
         CachableView $view,
         ParameterBag $requestAttributes,
         ResponseTagger $dispatcherTagger
-    ) {
+    ): void {
         $requestAttributes->get('view')->willReturn($view);
         $view->isCacheEnabled()->willReturn(true);
 

--- a/spec/EventSubscriber/RestKernelViewSubscriberSpec.php
+++ b/spec/EventSubscriber/RestKernelViewSubscriberSpec.php
@@ -31,7 +31,7 @@ class RestKernelViewSubscriberSpec extends ObjectBehavior
         Request $request,
         ParameterBag $attributes,
         ResponseTagger $tagHandler
-    ) {
+    ): void {
         $request->attributes = $attributes;
 
         $this->beConstructedWith($tagHandler);
@@ -42,7 +42,7 @@ class RestKernelViewSubscriberSpec extends ObjectBehavior
         Request $request,
         Response $response,
         ParameterBag $attributes
-    ) {
+    ): void {
         $request->isMethodCacheable()->willReturn(false);
         $attributes->get(new AnyValueToken())->shouldNotBeCalled();
 
@@ -61,7 +61,7 @@ class RestKernelViewSubscriberSpec extends ObjectBehavior
         Request $request,
         Response $response,
         ParameterBag $attributes
-    ) {
+    ): void {
         $request->isMethodCacheable()->willReturn(true);
         $attributes->get('is_rest_request')->willReturn(false);
 
@@ -84,7 +84,7 @@ class RestKernelViewSubscriberSpec extends ObjectBehavior
         ParameterBag $attributes,
         Section $restValue,
         ResponseTagger $tagHandler
-    ) {
+    ): void {
         $restValue->beConstructedWith([['id' => 5]]);
 
         $request->isMethodCacheable()->willReturn(true);
@@ -112,7 +112,7 @@ class RestKernelViewSubscriberSpec extends ObjectBehavior
         ParameterBag $attributes,
         ContentType $restValue,
         ResponseTagger $tagHandler
-    ) {
+    ): void {
         $restValue->beConstructedWith([['status' => ContentType::STATUS_DRAFT]]);
 
         $request->isMethodCacheable()->willReturn(true);
@@ -136,7 +136,7 @@ class RestKernelViewSubscriberSpec extends ObjectBehavior
         ParameterBag $attributes,
         ContentType $restValue,
         ResponseTagger $tagHandler
-    ) {
+    ): void {
         $restValue->beConstructedWith([['id' => 4, 'status' => ContentType::STATUS_DEFINED]]);
 
         $request->isMethodCacheable()->willReturn(true);
@@ -164,7 +164,7 @@ class RestKernelViewSubscriberSpec extends ObjectBehavior
         RestContentType $restValue,
         ContentType $contentType,
         ResponseTagger $tagHandler
-    ) {
+    ): void {
         $contentType->beConstructedWith([['status' => ContentType::STATUS_DRAFT]]);
         $restValue->contentType = $contentType;
 
@@ -190,7 +190,7 @@ class RestKernelViewSubscriberSpec extends ObjectBehavior
         RestContentType $restValue,
         ContentType $contentType,
         ResponseTagger $tagHandler
-    ) {
+    ): void {
         $contentType->beConstructedWith([['id' => 4, 'status' => ContentType::STATUS_DEFINED]]);
         $restValue->contentType = $contentType;
 
@@ -220,7 +220,7 @@ class RestKernelViewSubscriberSpec extends ObjectBehavior
         ContentType $contentType,
         ContentTypeGroup $contentTypeGroup,
         ResponseTagger $tagHandler
-    ) {
+    ): void {
         $contentType->beConstructedWith([['status' => ContentType::STATUS_DRAFT]]);
         $restValue->contentType = $contentType;
         $restValue->contentTypeGroups = [$contentTypeGroup];
@@ -248,7 +248,7 @@ class RestKernelViewSubscriberSpec extends ObjectBehavior
         ContentType $contentType,
         ContentTypeGroup $contentTypeGroup,
         ResponseTagger $tagHandler
-    ) {
+    ): void {
         $contentType->beConstructedWith([['id' => 4, 'status' => ContentType::STATUS_DEFINED]]);
         $restValue->contentType = $contentType;
 
@@ -280,7 +280,7 @@ class RestKernelViewSubscriberSpec extends ObjectBehavior
         ContentTypeGroupList $restValue,
         ContentTypeGroup $contentTypeGroup,
         ResponseTagger $tagHandler
-    ) {
+    ): void {
         $contentTypeGroup->beConstructedWith([['id' => 2]]);
         $restValue->contentTypeGroups = [$contentTypeGroup];
 
@@ -310,7 +310,7 @@ class RestKernelViewSubscriberSpec extends ObjectBehavior
         VersionInfo $versionInfo,
         ContentInfo $contentInfo,
         ResponseTagger $tagHandler
-    ) {
+    ): void {
         $contentInfo->beConstructedWith([['id' => 33]]);
         $versionInfo->beConstructedWith([['contentInfo' => $contentInfo]]);
         $restValue->versions = [$versionInfo];

--- a/spec/EventSubscriber/UserContextSubscriberSpec.php
+++ b/spec/EventSubscriber/UserContextSubscriberSpec.php
@@ -24,13 +24,13 @@ class UserContextSubscriberSpec extends ObjectBehavior
         RepositoryTagPrefix $prefixService,
         Response $response,
         ResponseHeaderBag $responseHeaders
-    ) {
+    ): void {
         $response->headers = $responseHeaders;
 
         $this->beConstructedWith($prefixService, 'xkey');
     }
 
-    public function it_is_initializable()
+    public function it_is_initializable(): void
     {
         $this->shouldHaveType(UserContextSubscriber::class);
     }
@@ -40,7 +40,7 @@ class UserContextSubscriberSpec extends ObjectBehavior
         Request $request,
         Response $response,
         ResponseHeaderBag $responseHeaders
-    ) {
+    ): void {
         $response->getTtl()->shouldNotBecalled();
         $response->isCacheable()->willReturn(false);
 
@@ -62,7 +62,7 @@ class UserContextSubscriberSpec extends ObjectBehavior
         Request $request,
         Response $response,
         ResponseHeaderBag $responseHeaders
-    ) {
+    ): void {
         $response->isCacheable()->willReturn(true);
         $responseHeaders->get(Argument::exact('Content-Type'))->willReturn('text/html');
 
@@ -84,7 +84,7 @@ class UserContextSubscriberSpec extends ObjectBehavior
         Request $request,
         Response $response,
         ResponseHeaderBag $responseHeaders
-    ) {
+    ): void {
         $response->isCacheable()->willReturn(true);
         $responseHeaders->get(Argument::exact('Content-Type'))->willReturn('application/vnd.fos.user-context-hash');
         $response->getTtl()->willReturn(0);
@@ -107,7 +107,7 @@ class UserContextSubscriberSpec extends ObjectBehavior
         Response $response,
         ResponseHeaderBag $responseHeaders,
         RepositoryTagPrefix $prefixService
-    ) {
+    ): void {
         $response->isCacheable()->willReturn(true);
         $responseHeaders->get(Argument::exact('Content-Type'))->willReturn('application/vnd.fos.user-context-hash');
         $response->getTtl()->willReturn(100);
@@ -131,7 +131,7 @@ class UserContextSubscriberSpec extends ObjectBehavior
         Response $response,
         ResponseHeaderBag $responseHeaders,
         RepositoryTagPrefix $prefixService
-    ) {
+    ): void {
         $response->isCacheable()->willReturn(true);
         $responseHeaders->get(Argument::exact('Content-Type'))->willReturn('application/vnd.fos.user-context-hash');
         $response->getTtl()->willReturn(100);

--- a/spec/EventSubscriber/XLocationIdResponseSubscriberSpec.php
+++ b/spec/EventSubscriber/XLocationIdResponseSubscriberSpec.php
@@ -27,7 +27,7 @@ class XLocationIdResponseSubscriberSpec extends ObjectBehavior
         ResponseTagger $tagHandler,
         Repository $repository,
         ResponseHeaderBag $responseHeaders
-    ) {
+    ): void {
         $response->headers = $responseHeaders;
 
         $this->beConstructedWith($tagHandler, $repository);
@@ -38,7 +38,7 @@ class XLocationIdResponseSubscriberSpec extends ObjectBehavior
         Request $request,
         Response $response,
         ResponseHeaderBag $responseHeaders
-    ) {
+    ): void {
         $responseHeaders->has('X-Location-Id')->willReturn(false);
         $responseHeaders->set()->shouldNotBecalled();
 
@@ -59,7 +59,7 @@ class XLocationIdResponseSubscriberSpec extends ObjectBehavior
         ResponseTagger $tagHandler,
         Repository $repository,
         ResponseHeaderBag $responseHeaders
-    ) {
+    ): void {
         $responseHeaders->has('X-Location-Id')->willReturn(true);
         $responseHeaders->get('X-Location-Id')->willReturn('123');
 
@@ -103,7 +103,7 @@ class XLocationIdResponseSubscriberSpec extends ObjectBehavior
         ResponseTagger $tagHandler,
         Repository $repository,
         ResponseHeaderBag $responseHeaders
-    ) {
+    ): void {
         $responseHeaders->has('X-Location-Id')->willReturn(true);
         $responseHeaders->get('X-Location-Id')->willReturn('123');
 
@@ -131,7 +131,7 @@ class XLocationIdResponseSubscriberSpec extends ObjectBehavior
         ResponseTagger $tagHandler,
         Repository $repository,
         ResponseHeaderBag $responseHeaders
-    ) {
+    ): void {
         $responseHeaders->has('X-Location-Id')->willReturn(true);
         $responseHeaders->get('X-Location-Id')->willReturn('123,34');
 

--- a/spec/Handler/TagHandlerSpec.php
+++ b/spec/Handler/TagHandlerSpec.php
@@ -1,13 +1,15 @@
 <?php
+
 /**
  * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
+
 namespace spec\Ibexa\HttpCache\Handler;
 
-use Ibexa\HttpCache\RepositoryTagPrefix;
 use FOS\HttpCache\TagHeaderFormatter\CommaSeparatedTagHeaderFormatter;
 use FOS\HttpCacheBundle\CacheManager;
+use Ibexa\HttpCache\RepositoryTagPrefix;
 use PhpSpec\ObjectBehavior;
 use Prophecy\Argument;
 use Psr\Log\LoggerInterface;
@@ -22,7 +24,7 @@ class TagHandlerSpec extends ObjectBehavior
         ResponseHeaderBag $responseHeaderBag,
         RepositoryTagPrefix $tagPrefix,
         LoggerInterface $logger
-    ) {
+    ): void {
         $response->headers = $responseHeaderBag;
         $cacheManager->supports(CacheManager::INVALIDATE)->willReturn(true);
 
@@ -36,7 +38,7 @@ class TagHandlerSpec extends ObjectBehavior
         $tagPrefix->getRepositoryPrefix()->willReturn('');
     }
 
-    public function it_only_tags_ez_all_when_no_tags(Response $response, ResponseHeaderBag $responseHeaderBag)
+    public function it_only_tags_ez_all_when_no_tags(Response $response, ResponseHeaderBag $responseHeaderBag): void
     {
         $responseHeaderBag->has('xkey')->willReturn(false);
         $responseHeaderBag->set('xkey', Argument::exact('ez-all'))->shouldBeCalled();
@@ -44,7 +46,7 @@ class TagHandlerSpec extends ObjectBehavior
         $this->tagSymfonyResponse($response, false);
     }
 
-    public function it_only_tags_ez_all_when_no_tags_also_on_replace(Response $response, ResponseHeaderBag $responseHeaderBag)
+    public function it_only_tags_ez_all_when_no_tags_also_on_replace(Response $response, ResponseHeaderBag $responseHeaderBag): void
     {
         $responseHeaderBag->has('xkey')->shouldNotBeCalled();
         $responseHeaderBag->set('xkey', Argument::exact('ez-all'))->shouldBeCalled();
@@ -52,7 +54,7 @@ class TagHandlerSpec extends ObjectBehavior
         $this->tagSymfonyResponse($response, true);
     }
 
-    public function it_tags_with_existing_header_string(Response $response, ResponseHeaderBag $responseHeaderBag)
+    public function it_tags_with_existing_header_string(Response $response, ResponseHeaderBag $responseHeaderBag): void
     {
         $responseHeaderBag->has('xkey')->willReturn(true);
         $responseHeaderBag->all('xkey')->willReturn(['tag1,tag2 tag3']);
@@ -61,7 +63,7 @@ class TagHandlerSpec extends ObjectBehavior
         $this->tagSymfonyResponse($response);
     }
 
-    public function it_tags_with_existing_header_array(Response $response, ResponseHeaderBag $responseHeaderBag)
+    public function it_tags_with_existing_header_array(Response $response, ResponseHeaderBag $responseHeaderBag): void
     {
         $responseHeaderBag->has('xkey')->willReturn(true);
         $responseHeaderBag->all('xkey')->willReturn(['tag1', 'tag2', 'tag3']);
@@ -70,7 +72,7 @@ class TagHandlerSpec extends ObjectBehavior
         $this->tagSymfonyResponse($response);
     }
 
-    public function it_tags_with_existing_header_mixed(Response $response, ResponseHeaderBag $responseHeaderBag)
+    public function it_tags_with_existing_header_mixed(Response $response, ResponseHeaderBag $responseHeaderBag): void
     {
         $responseHeaderBag->has('xkey')->willReturn(true);
         $responseHeaderBag->all('xkey')->willReturn(['tag1', 'tag2,tag3']);
@@ -79,7 +81,7 @@ class TagHandlerSpec extends ObjectBehavior
         $this->tagSymfonyResponse($response);
     }
 
-    public function it_tags_all_tags_we_add(Response $response, ResponseHeaderBag $responseHeaderBag)
+    public function it_tags_all_tags_we_add(Response $response, ResponseHeaderBag $responseHeaderBag): void
     {
         $responseHeaderBag->set('xkey', Argument::exact('ez-all l4 c4 p2'))->shouldBeCalled();
 
@@ -88,7 +90,7 @@ class TagHandlerSpec extends ObjectBehavior
         $this->tagSymfonyResponse($response, true);
     }
 
-    public function it_tags_all_tags_we_add_and_prefix_with_repo_id(Response $response, ResponseHeaderBag $responseHeaderBag, RepositoryTagPrefix $tagPrefix)
+    public function it_tags_all_tags_we_add_and_prefix_with_repo_id(Response $response, ResponseHeaderBag $responseHeaderBag, RepositoryTagPrefix $tagPrefix): void
     {
         $tagPrefix->getRepositoryPrefix()->willReturn('0');
         $responseHeaderBag->set('xkey', Argument::exact('ez-all 0ez-all 0l4 0c4 0p2'))->shouldBeCalled();
@@ -98,7 +100,7 @@ class TagHandlerSpec extends ObjectBehavior
         $this->tagSymfonyResponse($response, true);
     }
 
-    public function it_tags_all_tags_we_add_and_prefix_with_repo_id_also_with_existing_header(Response $response, ResponseHeaderBag $responseHeaderBag, RepositoryTagPrefix $tagPrefix)
+    public function it_tags_all_tags_we_add_and_prefix_with_repo_id_also_with_existing_header(Response $response, ResponseHeaderBag $responseHeaderBag, RepositoryTagPrefix $tagPrefix): void
     {
         $tagPrefix->getRepositoryPrefix()->willReturn('2');
         $responseHeaderBag->has('xkey')->willReturn(true);
@@ -110,14 +112,14 @@ class TagHandlerSpec extends ObjectBehavior
         $this->tagSymfonyResponse($response, false);
     }
 
-    public function it_ignores_too_long_tag_header(Response $response, ResponseHeaderBag $responseHeaderBag, LoggerInterface $logger)
+    public function it_ignores_too_long_tag_header(Response $response, ResponseHeaderBag $responseHeaderBag, LoggerInterface $logger): void
     {
         $underLimitTags = 'ez-all';
         $length = 6;
         while(true) {
             $tag = ' c' . $length;
             $tagLength = strlen($tag);
-            if ($length + $tagLength  > 1000) {
+            if ($length + $tagLength > 1000) {
                 break; // too long if we add more
             }
             $underLimitTags .= $tag;
@@ -133,14 +135,14 @@ class TagHandlerSpec extends ObjectBehavior
         $this->tagSymfonyResponse($response, true);
     }
 
-    public function it_ignores_too_long_tag_header_and_reduces_ttl(Response $response, ResponseHeaderBag $responseHeaderBag)
+    public function it_ignores_too_long_tag_header_and_reduces_ttl(Response $response, ResponseHeaderBag $responseHeaderBag): void
     {
         $underLimitTags = 'ez-all';
         $length = 6;
         while(true) {
             $tag = ' c' . $length;
             $tagLength = strlen($tag);
-            if ($length + $tagLength  > 1000) {
+            if ($length + $tagLength > 1000) {
                 break; // too long if we add more
             }
             $underLimitTags .= $tag;

--- a/spec/ProxyClient/VarnishSpec.php
+++ b/spec/ProxyClient/VarnishSpec.php
@@ -1,22 +1,24 @@
 <?php
+
 /**
  * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
+
 namespace spec\Ibexa\HttpCache\ProxyClient;
 
-use Ibexa\Contracts\Core\SiteAccess\ConfigResolverInterface;
 use FOS\HttpCache\ProxyClient\Dispatcher;
 use Http\Message\RequestFactory;
+use Ibexa\Contracts\Core\SiteAccess\ConfigResolverInterface;
 use PhpSpec\ObjectBehavior;
 use Prophecy\Argument;
 use Psr\Http\Message\RequestInterface;
 
 class VarnishSpec extends ObjectBehavior
 {
-    private const URI = "/";
+    private const URI = '/';
     private const REQUEST_HEADERS = [
-        "X-Some-Header" => "__SOME_HEADER_VALUE__"
+        'X-Some-Header' => '__SOME_HEADER_VALUE__',
     ];
 
     public function let(
@@ -24,8 +26,7 @@ class VarnishSpec extends ObjectBehavior
         Dispatcher $httpDispatcher,
         RequestFactory $messageFactory,
         RequestInterface $request
-
-    ) {
+    ): void {
         $messageFactory->createRequest(
             Argument::any(),
             Argument::any(),
@@ -39,14 +40,14 @@ class VarnishSpec extends ObjectBehavior
     public function it_should_purge_with_additional_token_header_when_configuration_key_with_token_is_not_null(
         ConfigResolverInterface $configResolver,
         RequestFactory $messageFactory
-    ) {
+    ): void {
         $configResolver->hasParameter('http_cache.varnish_invalidate_token')->willReturn(true);
         $configResolver->getParameter('http_cache.varnish_invalidate_token')->willReturn('__TOKEN__');
 
         $this->purge(self::URI, self::REQUEST_HEADERS);
 
         $this->requestShouldHaveBeenCreatedWithHeaders(
-            array_merge(self::REQUEST_HEADERS, ["X-Invalidate-Token" => "__TOKEN__"]),
+            array_merge(self::REQUEST_HEADERS, ['X-Invalidate-Token' => '__TOKEN__']),
             $messageFactory
         );
     }
@@ -54,7 +55,7 @@ class VarnishSpec extends ObjectBehavior
     public function it_should_purge_without_additional_token_header_when_configuration_key_with_token_do_not_exist_in_configuration(
         ConfigResolverInterface $configResolver,
         RequestFactory $messageFactory
-    ) {
+    ): void {
         $configResolver->hasParameter('http_cache.varnish_invalidate_token')->willReturn(false);
 
         $this->purge(self::URI, self::REQUEST_HEADERS);
@@ -68,7 +69,7 @@ class VarnishSpec extends ObjectBehavior
     public function it_should_purge_without_additional_token_header_when_configuration_key_with_token_exists_but_is_null(
         ConfigResolverInterface $configResolver,
         RequestFactory $messageFactory
-    ) {
+    ): void {
         $configResolver->hasParameter('http_cache.varnish_invalidate_token')->willReturn(true);
         $configResolver->getParameter('http_cache.varnish_invalidate_token')->willReturn(null);
 
@@ -80,7 +81,7 @@ class VarnishSpec extends ObjectBehavior
         );
     }
 
-    private function requestShouldHaveBeenCreatedWithHeaders($headers, RequestFactory $messageFactory)
+    private function requestShouldHaveBeenCreatedWithHeaders(array $headers, RequestFactory $messageFactory): void
     {
         $messageFactory->createRequest(
             'PURGE',

--- a/spec/RepositoryTagPrefixSpec.php
+++ b/spec/RepositoryTagPrefixSpec.php
@@ -1,5 +1,10 @@
 <?php
 
+/**
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+
 namespace spec\Ibexa\HttpCache;
 
 use Ibexa\Contracts\Core\SiteAccess\ConfigResolverInterface;
@@ -9,38 +14,38 @@ use Prophecy\Argument;
 
 class RepositoryTagPrefixSpec extends ObjectBehavior
 {
-    public function let(ConfigResolverInterface $resolver)
+    public function let(ConfigResolverInterface $resolver): void
     {
         $this->beConstructedWith($resolver, ['default' => [], 'intra' => [], 'site' => []]);
     }
 
-    function it_is_initializable()
+    public function it_is_initializable(): void
     {
         $this->shouldHaveType(RepositoryTagPrefix::class);
     }
 
-    public function it_returns_empty_on_null(ConfigResolverInterface $resolver)
+    public function it_returns_empty_on_null(ConfigResolverInterface $resolver): void
     {
         $resolver->getParameter(Argument::exact('repository'))->willReturn(null);
 
         $this->getRepositoryPrefix()->shouldReturn('');
     }
 
-    public function it_returns_empty_on_default(ConfigResolverInterface $resolver)
+    public function it_returns_empty_on_default(ConfigResolverInterface $resolver): void
     {
         $resolver->getParameter(Argument::exact('repository'))->willReturn('default');
 
         $this->getRepositoryPrefix()->shouldReturn('');
     }
 
-    public function it_returns_value_on_non_default(ConfigResolverInterface $resolver)
+    public function it_returns_value_on_non_default(ConfigResolverInterface $resolver): void
     {
         $resolver->getParameter(Argument::exact('repository'))->willReturn('intra');
 
         $this->getRepositoryPrefix()->shouldReturn('1');
     }
 
-    public function it_returns_value_on_non_default_cross_check(ConfigResolverInterface $resolver)
+    public function it_returns_value_on_non_default_cross_check(ConfigResolverInterface $resolver): void
     {
         $resolver->getParameter(Argument::exact('repository'))->willReturn('site');
 

--- a/spec/ResponseConfigurator/ConfigurableResponseCacheConfiguratorSpec.php
+++ b/spec/ResponseConfigurator/ConfigurableResponseCacheConfiguratorSpec.php
@@ -1,5 +1,10 @@
 <?php
 
+/**
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+
 namespace spec\Ibexa\HttpCache\ResponseConfigurator;
 
 use Ibexa\Contracts\Core\SiteAccess\ConfigResolverInterface;
@@ -14,12 +19,12 @@ class ConfigurableResponseCacheConfiguratorSpec extends ObjectBehavior
         Response $response,
         ResponseHeaderBag $headers,
         ConfigResolverInterface $configResolver
-    ) {
+    ): void {
         $response->headers = $headers;
         $this->beConstructedWith($configResolver);
     }
 
-    public function it_is_initializable()
+    public function it_is_initializable(): void
     {
         $this->shouldHaveType(ConfigurableResponseCacheConfigurator::class);
     }
@@ -27,7 +32,7 @@ class ConfigurableResponseCacheConfiguratorSpec extends ObjectBehavior
     public function it_sets_cache_control_to_public_if_viewcache_is_enabled(
         ConfigResolverInterface $configResolver,
         Response $response
-    ) {
+    ): void {
         $configResolver->getParameter('content.view_cache')->willReturn(true);
         $configResolver->getParameter('content.ttl_cache')->willReturn(false);
         $configResolver->getParameter('content.default_ttl')->willReturn(0);
@@ -43,7 +48,7 @@ class ConfigurableResponseCacheConfiguratorSpec extends ObjectBehavior
     public function it_does_not_set_cache_control_if_viewcache_is_disabled(
         ConfigResolverInterface $configResolver,
         Response $response
-    ) {
+    ): void {
         $configResolver->getParameter('content.view_cache')->willReturn(false);
         $configResolver->getParameter('content.ttl_cache')->willReturn(false);
         $configResolver->getParameter('content.default_ttl')->willReturn(0);
@@ -57,7 +62,7 @@ class ConfigurableResponseCacheConfiguratorSpec extends ObjectBehavior
     public function it_does_not_set_shared_maxage_if_ttl_cache_is_disabled(
         ConfigResolverInterface $configResolver,
         Response $response
-    ) {
+    ): void {
         $configResolver->getParameter('content.view_cache')->willReturn(true);
         $configResolver->getParameter('content.ttl_cache')->willReturn(false);
         $configResolver->getParameter('content.default_ttl')->willReturn(30);
@@ -72,7 +77,7 @@ class ConfigurableResponseCacheConfiguratorSpec extends ObjectBehavior
         ConfigResolverInterface $configResolver,
         Response $response,
         ResponseHeaderBag $headers
-    ) {
+    ): void {
         $configResolver->getParameter('content.view_cache')->willReturn(true);
         $configResolver->getParameter('content.ttl_cache')->willReturn(true);
         $configResolver->getParameter('content.default_ttl')->willReturn(30);
@@ -89,7 +94,7 @@ class ConfigurableResponseCacheConfiguratorSpec extends ObjectBehavior
         ConfigResolverInterface $configResolver,
         Response $response,
         ResponseHeaderBag $headers
-    ) {
+    ): void {
         $configResolver->getParameter('content.view_cache')->willReturn(true);
         $configResolver->getParameter('content.ttl_cache')->willReturn(true);
         $configResolver->getParameter('content.default_ttl')->willReturn(30);

--- a/spec/ResponseTagger/Delegator/ContentValueViewTaggerSpec.php
+++ b/spec/ResponseTagger/Delegator/ContentValueViewTaggerSpec.php
@@ -1,23 +1,28 @@
 <?php
 
+/**
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+
 namespace spec\Ibexa\HttpCache\ResponseTagger\Delegator;
 
 use Ibexa\Contracts\Core\Repository\Values\Content\ContentInfo;
-use Ibexa\HttpCache\ResponseTagger\Delegator\ContentValueViewTagger;
 use Ibexa\Contracts\HttpCache\ResponseTagger\ResponseTagger;
 use Ibexa\Core\MVC\Symfony\View\ContentValueView;
 use Ibexa\Core\Repository\Values\Content\Content;
 use Ibexa\Core\Repository\Values\Content\VersionInfo;
+use Ibexa\HttpCache\ResponseTagger\Delegator\ContentValueViewTagger;
 use PhpSpec\ObjectBehavior;
 
 class ContentValueViewTaggerSpec extends ObjectBehavior
 {
-    public function let(ResponseTagger $contentInfoTagger)
+    public function let(ResponseTagger $contentInfoTagger): void
     {
         $this->beConstructedWith($contentInfoTagger);
     }
 
-    public function it_is_initializable()
+    public function it_is_initializable(): void
     {
         $this->shouldHaveType(ContentValueViewTagger::class);
     }
@@ -25,7 +30,7 @@ class ContentValueViewTaggerSpec extends ObjectBehavior
     public function it_delegates_tagging_of_the_content_info(
         ResponseTagger $contentInfoTagger,
         ContentValueView $view
-    ) {
+    ): void {
         $contentInfo = new ContentInfo();
         $content = new Content(['versionInfo' => new VersionInfo(['contentInfo' => $contentInfo])]);
         $view->getContent()->willReturn($content);

--- a/spec/ResponseTagger/Delegator/DispatcherTaggerSpec.php
+++ b/spec/ResponseTagger/Delegator/DispatcherTaggerSpec.php
@@ -1,20 +1,25 @@
 <?php
 
+/**
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+
 namespace spec\Ibexa\HttpCache\ResponseTagger\Delegator;
 
 use Ibexa\Contracts\Core\Repository\Values\ValueObject;
-use Ibexa\HttpCache\ResponseTagger\Delegator\DispatcherTagger;
 use Ibexa\Contracts\HttpCache\ResponseTagger\ResponseTagger;
+use Ibexa\HttpCache\ResponseTagger\Delegator\DispatcherTagger;
 use PhpSpec\ObjectBehavior;
 
 class DispatcherTaggerSpec extends ObjectBehavior
 {
-    public function let(ResponseTagger $taggerOne, ResponseTagger $taggerTwo)
+    public function let(ResponseTagger $taggerOne, ResponseTagger $taggerTwo): void
     {
         $this->beConstructedWith([$taggerOne, $taggerTwo]);
     }
 
-    public function it_is_initializable()
+    public function it_is_initializable(): void
     {
         $this->shouldHaveType(DispatcherTagger::class);
     }
@@ -23,7 +28,7 @@ class DispatcherTaggerSpec extends ObjectBehavior
         ResponseTagger $taggerOne,
         ResponseTagger $taggerTwo,
         ValueObject $value
-    ) {
+    ): void {
         $this->tag($value);
 
         $taggerOne->tag($value)->shouldHaveBeenCalled();

--- a/spec/ResponseTagger/Delegator/LocationValueViewTaggerSpec.php
+++ b/spec/ResponseTagger/Delegator/LocationValueViewTaggerSpec.php
@@ -1,21 +1,26 @@
 <?php
 
+/**
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+
 namespace spec\Ibexa\HttpCache\ResponseTagger\Delegator;
 
-use Ibexa\HttpCache\ResponseTagger\Delegator\LocationValueViewTagger;
 use Ibexa\Contracts\HttpCache\ResponseTagger\ResponseTagger;
 use Ibexa\Core\MVC\Symfony\View\LocationValueView;
 use Ibexa\Core\Repository\Values\Content\Location;
+use Ibexa\HttpCache\ResponseTagger\Delegator\LocationValueViewTagger;
 use PhpSpec\ObjectBehavior;
 
 class LocationValueViewTaggerSpec extends ObjectBehavior
 {
-    public function let(ResponseTagger $locationTagger)
+    public function let(ResponseTagger $locationTagger): void
     {
         $this->beConstructedWith($locationTagger);
     }
 
-    public function it_is_initializable()
+    public function it_is_initializable(): void
     {
         $this->shouldHaveType(LocationValueViewTagger::class);
     }
@@ -23,7 +28,7 @@ class LocationValueViewTaggerSpec extends ObjectBehavior
     public function it_delegates_tagging_of_the_location(
         ResponseTagger $locationTagger,
         LocationValueView $view
-    ) {
+    ): void {
         $location = new Location();
         $view->getLocation()->willReturn($location);
         $this->tag($view);

--- a/spec/ResponseTagger/Value/ContentInfoTaggerSpec.php
+++ b/spec/ResponseTagger/Value/ContentInfoTaggerSpec.php
@@ -1,32 +1,37 @@
 <?php
 
+/**
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+
 namespace spec\Ibexa\HttpCache\ResponseTagger\Value;
 
+use FOS\HttpCache\ResponseTagger;
 use Ibexa\Contracts\Core\Repository\Values\Content\ContentInfo;
 use Ibexa\HttpCache\ResponseTagger\Value\ContentInfoTagger;
-use FOS\HttpCache\ResponseTagger;
 use PhpSpec\ObjectBehavior;
 
 class ContentInfoTaggerSpec extends ObjectBehavior
 {
-    public function let(ResponseTagger $tagHandler)
+    public function let(ResponseTagger $tagHandler): void
     {
         $this->beConstructedWith($tagHandler);
     }
 
-    public function it_is_initializable()
+    public function it_is_initializable(): void
     {
         $this->shouldHaveType(ContentInfoTagger::class);
     }
 
-    public function it_ignores_non_content_info(ResponseTagger $tagHandler)
+    public function it_ignores_non_content_info(ResponseTagger $tagHandler): void
     {
         $this->tag(null);
 
         $tagHandler->addTags()->shouldNotHaveBeenCalled();
     }
 
-    public function it_tags_with_content_and_content_type_id(ResponseTagger $tagHandler)
+    public function it_tags_with_content_and_content_type_id(ResponseTagger $tagHandler): void
     {
         $value = new ContentInfo(['id' => 123, 'contentTypeId' => 987]);
 
@@ -35,7 +40,7 @@ class ContentInfoTaggerSpec extends ObjectBehavior
         $tagHandler->addTags(['c123', 'ct987'])->shouldHaveBeenCalled();
     }
 
-    public function it_tags_with_location_id_if_one_is_set(ResponseTagger $tagHandler)
+    public function it_tags_with_location_id_if_one_is_set(ResponseTagger $tagHandler): void
     {
         $value = new ContentInfo(['mainLocationId' => 456]);
 

--- a/spec/ResponseTagger/Value/LocationTaggerSpec.php
+++ b/spec/ResponseTagger/Value/LocationTaggerSpec.php
@@ -1,34 +1,39 @@
 <?php
 
+/**
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+
 namespace spec\Ibexa\HttpCache\ResponseTagger\Value;
 
-use Ibexa\Contracts\Core\Repository\Values\Content\ContentInfo;
-use Ibexa\HttpCache\ResponseTagger\Value\LocationTagger;
-use Ibexa\Core\Repository\Values\Content\Location;
 use FOS\HttpCache\ResponseTagger;
+use Ibexa\Contracts\Core\Repository\Values\Content\ContentInfo;
+use Ibexa\Core\Repository\Values\Content\Location;
+use Ibexa\HttpCache\ResponseTagger\Value\LocationTagger;
 use PhpSpec\ObjectBehavior;
 use Prophecy\Argument;
 
 class LocationTaggerSpec extends ObjectBehavior
 {
-    public function let(ResponseTagger $tagHandler)
+    public function let(ResponseTagger $tagHandler): void
     {
         $this->beConstructedWith($tagHandler);
     }
 
-    public function it_is_initializable()
+    public function it_is_initializable(): void
     {
         $this->shouldHaveType(LocationTagger::class);
     }
 
-    public function it_ignores_non_location(ResponseTagger $tagHandler)
+    public function it_ignores_non_location(ResponseTagger $tagHandler): void
     {
         $this->tag(null);
 
         $tagHandler->addTags(Argument::any())->shouldNotHaveBeenCalled();
     }
 
-    public function it_tags_with_location_id_if_not_main_location(ResponseTagger $tagHandler)
+    public function it_tags_with_location_id_if_not_main_location(ResponseTagger $tagHandler): void
     {
         $value = new Location(['id' => 123, 'contentInfo' => new ContentInfo(['mainLocationId' => 321])]);
         $this->tag($value);
@@ -36,7 +41,7 @@ class LocationTaggerSpec extends ObjectBehavior
         $tagHandler->addTags(['l123'])->shouldHaveBeenCalled();
     }
 
-    public function it_tags_with_parent_location_id(ResponseTagger $tagHandler)
+    public function it_tags_with_parent_location_id(ResponseTagger $tagHandler): void
     {
         $value = new Location(['parentLocationId' => 123, 'contentInfo' => new ContentInfo()]);
 
@@ -45,7 +50,7 @@ class LocationTaggerSpec extends ObjectBehavior
         $tagHandler->addTags(['pl123'])->shouldHaveBeenCalled();
     }
 
-    public function it_tags_with_path_items(ResponseTagger $tagHandler)
+    public function it_tags_with_path_items(ResponseTagger $tagHandler): void
     {
         $value = new Location(['pathString' => '/1/2/123', 'contentInfo' => new ContentInfo()]);
 

--- a/src/bundle/AppCache.php
+++ b/src/bundle/AppCache.php
@@ -32,7 +32,7 @@ class AppCache extends HttpCache implements CacheInvalidation
         handle as protected baseHandle;
     }
 
-    public function __construct(KernelInterface $kernel, $cacheDir = null)
+    public function __construct(KernelInterface $kernel, string|StoreInterface|null $cacheDir = null)
     {
         parent::__construct($kernel, $cacheDir);
         $this->addSubscriber(new UserContextListener(['session_name_prefix' => 'IBX_SESSION_ID']));
@@ -40,7 +40,7 @@ class AppCache extends HttpCache implements CacheInvalidation
         $this->addSubscriber(new PurgeListener(['client_ips' => $this->getInternalAllowedIPs()]));
     }
 
-    public function fetch(Request $request, $catch = false): Response
+    public function fetch(Request $request, bool $catch = false): Response
     {
         return parent::fetch($request, $catch);
     }

--- a/src/bundle/Controller/InvalidateTokenController.php
+++ b/src/bundle/Controller/InvalidateTokenController.php
@@ -17,10 +17,7 @@ class InvalidateTokenController
 {
     public const TOKEN_HEADER_NAME = 'X-Invalidate-Token';
 
-    /**
-     * @var \Ibexa\Contracts\Core\SiteAccess\ConfigResolverInterface
-     */
-    private $configResolver;
+    private ConfigResolverInterface $configResolver;
 
     /**
      * @var int
@@ -30,7 +27,7 @@ class InvalidateTokenController
     /**
      * @var \Ibexa\HttpCache\Handler\TagHandler
      */
-    private $tagHandler;
+    private ResponseTagger $tagHandler;
 
     /**
      * TokenController constructor.

--- a/src/bundle/DependencyInjection/Compiler/DriverPass.php
+++ b/src/bundle/DependencyInjection/Compiler/DriverPass.php
@@ -42,7 +42,7 @@ class DriverPass implements CompilerPassInterface
         $container->setAlias(ContentTagInterface::class, 'fos_http_cache.http.symfony_response_tagger');
     }
 
-    public static function getTaggedService(ContainerBuilder $container, $tag): string|null
+    public static function getTaggedService(ContainerBuilder $container, string $tag): string|null
     {
         $purgeType = $container->getParameter('ibexa.http_cache.purge_type');
         $configuredTagHandlerServiceId = null;

--- a/src/bundle/DependencyInjection/ConfigResolver/HttpCacheConfigParser.php
+++ b/src/bundle/DependencyInjection/ConfigResolver/HttpCacheConfigParser.php
@@ -14,17 +14,14 @@ use Symfony\Component\DependencyInjection\Extension\ExtensionInterface;
 
 class HttpCacheConfigParser implements ParserInterface
 {
-    /**
-     * @var \Symfony\Component\DependencyInjection\Extension\ExtensionInterface
-     */
-    private $httpCacheExtension;
+    private ExtensionInterface $httpCacheExtension;
 
     public function __construct(ExtensionInterface $httpCacheExtension)
     {
         $this->httpCacheExtension = $httpCacheExtension;
     }
 
-    public function addSemanticConfig(NodeBuilder $nodeBuilder)
+    public function addSemanticConfig(NodeBuilder $nodeBuilder): void
     {
         $subBuilder = $nodeBuilder
             ->arrayNode('http_cache')
@@ -48,7 +45,7 @@ class HttpCacheConfigParser implements ParserInterface
         $nodeBuilder->end()->end();
     }
 
-    public function mapConfig(array &$scopeSettings, $currentScope, ContextualizerInterface $contextualizer)
+    public function mapConfig(array &$scopeSettings, $currentScope, ContextualizerInterface $contextualizer): void
     {
         if (!isset($scopeSettings['http_cache'])) {
             return;
@@ -67,7 +64,7 @@ class HttpCacheConfigParser implements ParserInterface
         }
     }
 
-    public function preMap(array $config, ContextualizerInterface $contextualizer)
+    public function preMap(array $config, ContextualizerInterface $contextualizer): void
     {
         if (!isset($config['http_cache'])) {
             return;
@@ -78,7 +75,7 @@ class HttpCacheConfigParser implements ParserInterface
         }
     }
 
-    public function postMap(array $config, ContextualizerInterface $contextualizer)
+    public function postMap(array $config, ContextualizerInterface $contextualizer): void
     {
         if (!isset($config['http_cache'])) {
             return;

--- a/src/bundle/DependencyInjection/IbexaHttpCacheExtension.php
+++ b/src/bundle/DependencyInjection/IbexaHttpCacheExtension.php
@@ -22,14 +22,14 @@ class IbexaHttpCacheExtension extends Extension implements PrependExtensionInter
     /**
      * @var \Ibexa\Bundle\Core\DependencyInjection\Configuration\ParserInterface[]
      */
-    private $extraConfigParsers = [];
+    private array $extraConfigParsers = [];
 
     public function getAlias(): string
     {
         return 'ibexa_http_cache';
     }
 
-    public function load(array $configs, ContainerBuilder $container)
+    public function load(array $configs, ContainerBuilder $container): void
     {
         $configuration = new Configuration();
         $config = $this->processConfiguration($configuration, $configs);
@@ -49,7 +49,7 @@ class IbexaHttpCacheExtension extends Extension implements PrependExtensionInter
         }
     }
 
-    public function prepend(ContainerBuilder $container)
+    public function prepend(ContainerBuilder $container): void
     {
         // Load params early as we use them in below
         $loader = new Loader\YamlFileLoader($container, new FileLocator(__DIR__ . '/../Resources/config'));
@@ -67,7 +67,7 @@ class IbexaHttpCacheExtension extends Extension implements PrependExtensionInter
         $container->addResource(new FileResource($coreExtensionConfigFile));
     }
 
-    public function addExtraConfigParser(ParserInterface $configParser)
+    public function addExtraConfigParser(ParserInterface $configParser): void
     {
         $this->extraConfigParsers[] = $configParser;
     }

--- a/src/lib/ContextProvider/RoleIdentify.php
+++ b/src/lib/ContextProvider/RoleIdentify.php
@@ -26,13 +26,11 @@ use Ibexa\Contracts\Core\Repository\UserService;
 class RoleIdentify implements ContextProvider
 {
     /** @var \Ibexa\Core\Repository\Repository */
-    protected $repository;
+    protected Repository $repository;
 
-    /** @var \Ibexa\Contracts\Core\Repository\PermissionResolver */
-    private $permissionResolver;
+    private PermissionResolver $permissionResolver;
 
-    /** @var \Ibexa\Contracts\Core\Repository\UserService */
-    private $userService;
+    private UserService $userService;
 
     public function __construct(
         Repository $repository,
@@ -44,7 +42,7 @@ class RoleIdentify implements ContextProvider
         $this->userService = $userService;
     }
 
-    public function updateUserContext(UserContext $context)
+    public function updateUserContext(UserContext $context): void
     {
         $user = $this->userService->loadUser(
             $this->permissionResolver->getCurrentUserReference()->getUserId()
@@ -52,7 +50,7 @@ class RoleIdentify implements ContextProvider
 
         /** @var \Ibexa\Contracts\Core\Repository\Values\User\RoleAssignment[] $roleAssignments */
         $roleAssignments = $this->repository->sudo(
-            static function (Repository $repository) use ($user) {
+            static function (Repository $repository) use ($user): iterable {
                 return $repository->getRoleService()->getRoleAssignmentsForUser($user, true);
             }
         );

--- a/src/lib/EventListener/ConditionallyRemoveVaryHeaderListener.php
+++ b/src/lib/EventListener/ConditionallyRemoveVaryHeaderListener.php
@@ -23,12 +23,12 @@ class ConditionallyRemoveVaryHeaderListener implements EventSubscriberInterface
     /**
      * @var string[]
      */
-    private $routes;
+    private array $routes;
 
     /**
      * @var string[]
      */
-    private $userIdentifierHeaders;
+    private array $userIdentifierHeaders;
 
     /**
      * ConditionallyRemoveVaryHeaderListener constructor.
@@ -47,7 +47,7 @@ class ConditionallyRemoveVaryHeaderListener implements EventSubscriberInterface
      *
      * @param \Symfony\Component\HttpKernel\Event\ResponseEvent $event
      */
-    public function onKernelResponse(ResponseEvent $event)
+    public function onKernelResponse(ResponseEvent $event): void
     {
         if (HttpKernelInterface::MAIN_REQUEST !== $event->getRequestType()) {
             return;

--- a/src/lib/EventSubscriber/AddContentLanguageHeaderSubscriber.php
+++ b/src/lib/EventSubscriber/AddContentLanguageHeaderSubscriber.php
@@ -19,15 +19,14 @@ final class AddContentLanguageHeaderSubscriber implements EventSubscriberInterfa
 {
     public const CONTENT_LANGUAGE_HEADER = 'x-lang';
 
-    /** @var bool */
-    private $isTranslationAware;
+    private bool $isTranslationAware;
 
     public function __construct(bool $isTranslationAware)
     {
         $this->isTranslationAware = $isTranslationAware;
     }
 
-    public function onKernelResponse(ResponseEvent $event)
+    public function onKernelResponse(ResponseEvent $event): void
     {
         if (!$this->isTranslationAware || HttpKernelInterface::MAIN_REQUEST != $event->getRequestType()) {
             return;

--- a/src/lib/EventSubscriber/CachePurge/AbstractSubscriber.php
+++ b/src/lib/EventSubscriber/CachePurge/AbstractSubscriber.php
@@ -9,6 +9,7 @@ declare(strict_types=1);
 namespace Ibexa\HttpCache\EventSubscriber\CachePurge;
 
 use Ibexa\Contracts\Core\Persistence\Content\Location\Handler as LocationHandler;
+use Ibexa\Contracts\Core\Persistence\URL\Handler;
 use Ibexa\Contracts\Core\Persistence\URL\Handler as UrlHandler;
 use Ibexa\Contracts\HttpCache\Handler\ContentTagInterface;
 use Ibexa\Contracts\HttpCache\PurgeClient\PurgeClientInterface;
@@ -19,14 +20,11 @@ use Symfony\Component\EventDispatcher\EventSubscriberInterface;
  */
 abstract class AbstractSubscriber implements EventSubscriberInterface
 {
-    /** @var \Ibexa\Contracts\HttpCache\PurgeClient\PurgeClientInterface */
-    protected $purgeClient;
+    protected PurgeClientInterface $purgeClient;
 
-    /** @var \Ibexa\Contracts\Core\Persistence\Content\Location\Handler */
-    private $locationHandler;
+    private LocationHandler $locationHandler;
 
-    /** @var \Ibexa\Contracts\Core\Persistence\URL\Handler */
-    private $urlHandler;
+    private Handler $urlHandler;
 
     public function __construct(
         PurgeClientInterface $purgeClient,

--- a/src/lib/EventSubscriber/CachePurge/ContentEventsSubscriber.php
+++ b/src/lib/EventSubscriber/CachePurge/ContentEventsSubscriber.php
@@ -8,6 +8,7 @@ declare(strict_types=1);
 
 namespace Ibexa\HttpCache\EventSubscriber\CachePurge;
 
+use Ibexa\Contracts\Core\Persistence\Content\Handler;
 use Ibexa\Contracts\Core\Persistence\Content\Handler as ContentHandler;
 use Ibexa\Contracts\Core\Persistence\Content\Location\Handler as LocationHandler;
 use Ibexa\Contracts\Core\Persistence\URL\Handler as UrlHandler;
@@ -28,11 +29,9 @@ use Ibexa\Contracts\HttpCache\PurgeClient\PurgeClientInterface;
 
 final class ContentEventsSubscriber extends AbstractSubscriber
 {
-    /** @var \Ibexa\Contracts\Core\Persistence\Content\Handler */
-    private $contentHandler;
+    private Handler $contentHandler;
 
-    /** @var bool */
-    private $isTranslationAware;
+    private bool $isTranslationAware;
 
     public function __construct(
         PurgeClientInterface $purgeClient,

--- a/src/lib/EventSubscriber/CachePurge/RoleEventsSubscriber.php
+++ b/src/lib/EventSubscriber/CachePurge/RoleEventsSubscriber.php
@@ -28,7 +28,7 @@ final class RoleEventsSubscriber extends AbstractSubscriber
         ];
     }
 
-    public function clearUserContextHashCache(Event $event)
+    public function clearUserContextHashCache(Event $event): void
     {
         $this->purgeClient->purge([
             'ez-user-context-hash',

--- a/src/lib/EventSubscriber/HiddenLocationExceptionSubscriber.php
+++ b/src/lib/EventSubscriber/HiddenLocationExceptionSubscriber.php
@@ -19,12 +19,9 @@ class HiddenLocationExceptionSubscriber implements EventSubscriberInterface
     /**
      * @var \Ibexa\HttpCache\ResponseTagger\Value\LocationTagger;
      */
-    private $locationTagger;
+    private LocationTagger $locationTagger;
 
-    /**
-     * @var \Ibexa\HttpCache\ResponseTagger\Value\ContentInfoTagger
-     */
-    private $contentInfoTagger;
+    private ContentInfoTagger $contentInfoTagger;
 
     public function __construct(LocationTagger $locationTagger, ContentInfoTagger $contentInfoTagger)
     {
@@ -37,7 +34,7 @@ class HiddenLocationExceptionSubscriber implements EventSubscriberInterface
         return [KernelEvents::EXCEPTION => ['tagHiddenLocationExceptionResponse', 10]];
     }
 
-    public function tagHiddenLocationExceptionResponse(ExceptionEvent $event)
+    public function tagHiddenLocationExceptionResponse(ExceptionEvent $event): void
     {
         if (!$event->getThrowable() instanceof HiddenLocationException) {
             return;

--- a/src/lib/EventSubscriber/HttpCacheResponseSubscriber.php
+++ b/src/lib/EventSubscriber/HttpCacheResponseSubscriber.php
@@ -19,15 +19,9 @@ use Symfony\Component\HttpKernel\KernelEvents;
  */
 class HttpCacheResponseSubscriber implements EventSubscriberInterface
 {
-    /**
-     * @var \Ibexa\Contracts\HttpCache\ResponseTagger\ResponseTagger
-     */
-    private $dispatcherTagger;
+    private ResponseTagger $dispatcherTagger;
 
-    /**
-     * @var \Ibexa\HttpCache\ResponseConfigurator\ResponseCacheConfigurator
-     */
-    private $responseConfigurator;
+    private ResponseCacheConfigurator $responseConfigurator;
 
     public function __construct(ResponseCacheConfigurator $responseConfigurator, ResponseTagger $dispatcherTagger)
     {
@@ -40,7 +34,7 @@ class HttpCacheResponseSubscriber implements EventSubscriberInterface
         return [KernelEvents::RESPONSE => ['configureCache', 10]];
     }
 
-    public function configureCache(ResponseEvent $event)
+    public function configureCache(ResponseEvent $event): void
     {
         $view = $event->getRequest()->attributes->get('view');
         if (!$view instanceof CachableView || !$view->isCacheEnabled()) {

--- a/src/lib/EventSubscriber/RequestEventSubscriber.php
+++ b/src/lib/EventSubscriber/RequestEventSubscriber.php
@@ -14,8 +14,7 @@ use Symfony\Component\HttpKernel\KernelEvents;
 
 final class RequestEventSubscriber implements EventSubscriberInterface
 {
-    /** @var string */
-    private $userHashHeaderName;
+    private string $userHashHeaderName;
 
     public function __construct(string $userHashHeaderName)
     {

--- a/src/lib/EventSubscriber/RestKernelViewSubscriber.php
+++ b/src/lib/EventSubscriber/RestKernelViewSubscriber.php
@@ -30,8 +30,7 @@ use Symfony\Component\HttpKernel\KernelEvents;
  */
 class RestKernelViewSubscriber implements EventSubscriberInterface
 {
-    /** @var \FOS\HttpCache\ResponseTagger */
-    private $tagHandler;
+    private ResponseTagger $tagHandler;
 
     public function __construct(ResponseTagger $tagHandler)
     {
@@ -43,7 +42,7 @@ class RestKernelViewSubscriber implements EventSubscriberInterface
         return [KernelEvents::VIEW => ['tagUIRestResult', 10]];
     }
 
-    public function tagUIRestResult(ViewEvent $event)
+    public function tagUIRestResult(ViewEvent $event): void
     {
         $request = $event->getRequest();
         if (!$request->isMethodCacheable() || !$request->attributes->get('is_rest_request')) {
@@ -67,7 +66,7 @@ class RestKernelViewSubscriber implements EventSubscriberInterface
      *
      * @return array
      */
-    protected function getTags($value)
+    protected function getTags($value): array
     {
         $tags = [];
         switch ($value) {

--- a/src/lib/EventSubscriber/UserContextSiteAccessMatchSubscriber.php
+++ b/src/lib/EventSubscriber/UserContextSiteAccessMatchSubscriber.php
@@ -16,11 +16,9 @@ use Symfony\Component\HttpKernel\KernelEvents;
 
 class UserContextSiteAccessMatchSubscriber implements EventSubscriberInterface
 {
-    /** @var \Ibexa\Core\MVC\Symfony\EventListener\SiteAccessMatchListener */
-    protected $innerSubscriber;
+    protected SiteAccessMatchListener $innerSubscriber;
 
-    /** @var \Symfony\Component\HttpFoundation\RequestMatcherInterface */
-    private $userContextRequestMatcher;
+    private RequestMatcherInterface $userContextRequestMatcher;
 
     public function __construct(
         SiteAccessMatchListener $innerSubscriber,
@@ -38,7 +36,7 @@ class UserContextSiteAccessMatchSubscriber implements EventSubscriberInterface
         ];
     }
 
-    public function checkIfRequestForUserContextHash(RequestEvent $event)
+    public function checkIfRequestForUserContextHash(RequestEvent $event): void
     {
         $request = $event->getRequest();
 

--- a/src/lib/EventSubscriber/UserContextSubscriber.php
+++ b/src/lib/EventSubscriber/UserContextSubscriber.php
@@ -18,15 +18,9 @@ use Symfony\Component\HttpKernel\KernelEvents;
  */
 class UserContextSubscriber implements EventSubscriberInterface
 {
-    /**
-     * @var \Ibexa\HttpCache\RepositoryTagPrefix
-     */
-    private $prefixService;
+    private RepositoryTagPrefix $prefixService;
 
-    /**
-     * @var string
-     */
-    private $tagHeader;
+    private string $tagHeader;
 
     public function __construct(
         RepositoryTagPrefix $prefixService,
@@ -46,7 +40,7 @@ class UserContextSubscriber implements EventSubscriberInterface
      *
      * @param \Symfony\Component\HttpKernel\Event\ResponseEvent $event
      */
-    public function tagUserContext(ResponseEvent $event)
+    public function tagUserContext(ResponseEvent $event): void
     {
         $response = $event->getResponse();
         if (!$response->isCacheable()) {

--- a/src/lib/EventSubscriber/XLocationIdResponseSubscriber.php
+++ b/src/lib/EventSubscriber/XLocationIdResponseSubscriber.php
@@ -10,6 +10,7 @@ namespace Ibexa\HttpCache\EventSubscriber;
 use FOS\HttpCache\ResponseTagger;
 use Ibexa\Contracts\Core\Repository\Exceptions\NotFoundException;
 use Ibexa\Contracts\Core\Repository\Repository;
+use Ibexa\Contracts\Core\Repository\Values\Content\Location;
 use Ibexa\Contracts\HttpCache\Handler\ContentTagInterface;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 use Symfony\Component\HttpKernel\Event\ResponseEvent;
@@ -60,7 +61,7 @@ class XLocationIdResponseSubscriber implements EventSubscriberInterface
             $id = trim($id);
             try {
                 /** @var $location \Ibexa\Contracts\Core\Repository\Values\Content\Location */
-                $location = $this->repository->sudo(static function (Repository $repository) use ($id): \Ibexa\Contracts\Core\Repository\Values\Content\Location {
+                $location = $this->repository->sudo(static function (Repository $repository) use ($id): Location {
                     return $repository->getLocationService()->loadLocation($id);
                 });
 

--- a/src/lib/EventSubscriber/XLocationIdResponseSubscriber.php
+++ b/src/lib/EventSubscriber/XLocationIdResponseSubscriber.php
@@ -27,11 +27,9 @@ class XLocationIdResponseSubscriber implements EventSubscriberInterface
 {
     public const LOCATION_ID_HEADER = 'X-Location-Id';
 
-    /** @var \FOS\HttpCache\ResponseTagger */
-    private $responseTagger;
+    private ResponseTagger $responseTagger;
 
-    /** @var \Ibexa\Contracts\Core\Repository\Repository */
-    private $repository;
+    private Repository $repository;
 
     public function __construct(ResponseTagger $responseTagger, Repository $repository)
     {
@@ -44,7 +42,7 @@ class XLocationIdResponseSubscriber implements EventSubscriberInterface
         return [KernelEvents::RESPONSE => ['rewriteCacheHeader', 10]];
     }
 
-    public function rewriteCacheHeader(ResponseEvent $event)
+    public function rewriteCacheHeader(ResponseEvent $event): void
     {
         $response = $event->getResponse();
         if (!$response->headers->has(static::LOCATION_ID_HEADER)) {
@@ -62,7 +60,7 @@ class XLocationIdResponseSubscriber implements EventSubscriberInterface
             $id = trim($id);
             try {
                 /** @var $location \Ibexa\Contracts\Core\Repository\Values\Content\Location */
-                $location = $this->repository->sudo(static function (Repository $repository) use ($id) {
+                $location = $this->repository->sudo(static function (Repository $repository) use ($id): \Ibexa\Contracts\Core\Repository\Values\Content\Location {
                     return $repository->getLocationService()->loadLocation($id);
                 });
 

--- a/src/lib/Handler/TagHandler.php
+++ b/src/lib/Handler/TagHandler.php
@@ -23,11 +23,9 @@ use Symfony\Component\HttpFoundation\Response;
  */
 class TagHandler extends SymfonyResponseTagger implements ContentTagInterface
 {
-    /** @var \Ibexa\HttpCache\RepositoryTagPrefix */
-    private $prefixService;
+    private RepositoryTagPrefix $prefixService;
 
-    /** @var \Psr\Log\LoggerInterface */
-    private $logger;
+    private LoggerInterface $logger;
 
     /** @var int|null */
     private $tagsHeaderMaxLength;
@@ -76,7 +74,7 @@ class TagHandler extends SymfonyResponseTagger implements ContentTagInterface
             $repoPrefix = $this->prefixService->getRepositoryPrefix();
             if ($repoPrefix !== '') {
                 $tags = array_map(
-                    static function ($tag) use ($repoPrefix) {
+                    static function (string $tag) use ($repoPrefix): string {
                         return $repoPrefix . $tag;
                     },
                     $tags
@@ -124,9 +122,9 @@ class TagHandler extends SymfonyResponseTagger implements ContentTagInterface
     /**
      * {@inheritdoc}
      */
-    public function addContentTags(array $contentIds)
+    public function addContentTags(array $contentIds): void
     {
-        $this->addTags(array_map(static function ($contentId) {
+        $this->addTags(array_map(static function (string $contentId): string {
             return ContentTagInterface::CONTENT_PREFIX . $contentId;
         }, $contentIds));
     }
@@ -134,9 +132,9 @@ class TagHandler extends SymfonyResponseTagger implements ContentTagInterface
     /**
      * {@inheritdoc}
      */
-    public function addLocationTags(array $locationIds)
+    public function addLocationTags(array $locationIds): void
     {
-        $this->addTags(array_map(static function ($locationId) {
+        $this->addTags(array_map(static function (string $locationId): string {
             return ContentTagInterface::LOCATION_PREFIX . $locationId;
         }, $locationIds));
     }
@@ -144,9 +142,9 @@ class TagHandler extends SymfonyResponseTagger implements ContentTagInterface
     /**
      * {@inheritdoc}
      */
-    public function addParentLocationTags(array $parentLocationIds)
+    public function addParentLocationTags(array $parentLocationIds): void
     {
-        $this->addTags(array_map(static function ($parentLocationId) {
+        $this->addTags(array_map(static function (string $parentLocationId): string {
             return ContentTagInterface::PARENT_LOCATION_PREFIX . $parentLocationId;
         }, $parentLocationIds));
     }
@@ -154,9 +152,9 @@ class TagHandler extends SymfonyResponseTagger implements ContentTagInterface
     /**
      * {@inheritdoc}
      */
-    public function addPathTags(array $locationIds)
+    public function addPathTags(array $locationIds): void
     {
-        $this->addTags(array_map(static function ($locationId) {
+        $this->addTags(array_map(static function (string $locationId): string {
             return ContentTagInterface::PATH_PREFIX . $locationId;
         }, $locationIds));
     }
@@ -164,9 +162,9 @@ class TagHandler extends SymfonyResponseTagger implements ContentTagInterface
     /**
      * {@inheritdoc}
      */
-    public function addRelationTags(array $contentIds)
+    public function addRelationTags(array $contentIds): void
     {
-        $this->addTags(array_map(static function ($contentId) {
+        $this->addTags(array_map(static function (string $contentId): string {
             return ContentTagInterface::RELATION_PREFIX . $contentId;
         }, $contentIds));
     }
@@ -174,9 +172,9 @@ class TagHandler extends SymfonyResponseTagger implements ContentTagInterface
     /**
      * {@inheritdoc}
      */
-    public function addRelationLocationTags(array $locationIds)
+    public function addRelationLocationTags(array $locationIds): void
     {
-        $this->addTags(array_map(static function ($locationId) {
+        $this->addTags(array_map(static function (string $locationId): string {
             return ContentTagInterface::RELATION_LOCATION_PREFIX . $locationId;
         }, $locationIds));
     }
@@ -184,9 +182,9 @@ class TagHandler extends SymfonyResponseTagger implements ContentTagInterface
     /**
      * {@inheritdoc}
      */
-    public function addContentTypeTags(array $contentTypeIds)
+    public function addContentTypeTags(array $contentTypeIds): void
     {
-        $this->addTags(array_map(static function ($contentTypeId) {
+        $this->addTags(array_map(static function (string $contentTypeId): string {
             return ContentTagInterface::CONTENT_TYPE_PREFIX . $contentTypeId;
         }, $contentTypeIds));
     }

--- a/src/lib/ProxyClient/HttpDispatcherFactory.php
+++ b/src/lib/ProxyClient/HttpDispatcherFactory.php
@@ -13,14 +13,11 @@ use Ibexa\Contracts\Core\SiteAccess\ConfigResolverInterface;
 
 class HttpDispatcherFactory
 {
-    /** @var \Ibexa\Contracts\Core\SiteAccess\ConfigResolverInterface */
-    private $configResolver;
+    private ConfigResolverInterface $configResolver;
 
-    /** @var \Ibexa\Bundle\Core\DependencyInjection\Configuration\SiteAccessAware\DynamicSettingParserInterface */
-    private $dynamicSettingParser;
+    private DynamicSettingParserInterface $dynamicSettingParser;
 
-    /** @var string */
-    private $httpDispatcherClass;
+    private string $httpDispatcherClass;
 
     public function __construct(
         ConfigResolverInterface $configResolver,

--- a/src/lib/ProxyClient/Varnish.php
+++ b/src/lib/ProxyClient/Varnish.php
@@ -20,8 +20,7 @@ use Ibexa\Contracts\Core\SiteAccess\ConfigResolverInterface;
 
 final class Varnish extends FosVarnish implements BanCapable, PurgeCapable, RefreshCapable, TagCapable
 {
-    /** @var \Ibexa\Contracts\Core\SiteAccess\ConfigResolverInterface */
-    private $configResolver;
+    private ConfigResolverInterface $configResolver;
 
     public function __construct(
         ConfigResolverInterface $configResolver,
@@ -52,7 +51,7 @@ final class Varnish extends FosVarnish implements BanCapable, PurgeCapable, Refr
         return null;
     }
 
-    protected function queueRequest($method, $url, array $headers, $validateHost = true, $body = null)
+    protected function queueRequest($method, $url, array $headers, $validateHost = true, $body = null): void
     {
         parent::queueRequest($method, $url, $this->fetchAndMergeAuthHeaders($headers), $body);
     }

--- a/src/lib/PurgeClient/LocalPurgeClient.php
+++ b/src/lib/PurgeClient/LocalPurgeClient.php
@@ -16,8 +16,7 @@ use Toflar\Psr6HttpCacheStore\Psr6StoreInterface;
  */
 class LocalPurgeClient implements PurgeClientInterface
 {
-    /** @var \Toflar\Psr6HttpCacheStore\Psr6StoreInterface */
-    protected $cacheStore;
+    protected Psr6StoreInterface $cacheStore;
 
     public function __construct(Psr6StoreInterface $cacheStore)
     {

--- a/src/lib/PurgeClient/RepositoryPrefixDecorator.php
+++ b/src/lib/PurgeClient/RepositoryPrefixDecorator.php
@@ -17,11 +17,9 @@ use Ibexa\HttpCache\RepositoryTagPrefix;
  */
 class RepositoryPrefixDecorator implements PurgeClientInterface
 {
-    /** @var \Ibexa\Contracts\HttpCache\PurgeClient\PurgeClientInterface */
-    private $purgeClient;
+    private PurgeClientInterface $purgeClient;
 
-    /** @var \Ibexa\HttpCache\RepositoryTagPrefix */
-    private $prefixService;
+    private RepositoryTagPrefix $prefixService;
 
     public function __construct(PurgeClientInterface $purgeClient, RepositoryTagPrefix $prefixService)
     {
@@ -37,7 +35,7 @@ class RepositoryPrefixDecorator implements PurgeClientInterface
 
         $repoPrefix = $this->prefixService->getRepositoryPrefix();
         $tags = array_map(
-            static function ($tag) use ($repoPrefix) {
+            static function (string $tag) use ($repoPrefix): string {
                 // Prefix tags with repository prefix
                 return $repoPrefix . $tag;
             },

--- a/src/lib/PurgeClient/VarnishPurgeClient.php
+++ b/src/lib/PurgeClient/VarnishPurgeClient.php
@@ -15,8 +15,7 @@ use Ibexa\Contracts\HttpCache\PurgeClient\PurgeClientInterface;
  */
 class VarnishPurgeClient implements PurgeClientInterface
 {
-    /** @var \FOS\HttpCacheBundle\CacheManager */
-    private $cacheManager;
+    private CacheManager $cacheManager;
 
     public function __construct(
         CacheManager $cacheManager

--- a/src/lib/ResponseConfigurator/ConfigurableResponseCacheConfigurator.php
+++ b/src/lib/ResponseConfigurator/ConfigurableResponseCacheConfigurator.php
@@ -16,15 +16,14 @@ use Symfony\Component\HttpFoundation\Response;
  */
 class ConfigurableResponseCacheConfigurator implements ResponseCacheConfigurator
 {
-    /** @var \Ibexa\Contracts\Core\SiteAccess\ConfigResolverInterface */
-    private $configResolver;
+    private ConfigResolverInterface $configResolver;
 
     public function __construct(ConfigResolverInterface $configResolver)
     {
         $this->configResolver = $configResolver;
     }
 
-    public function enableCache(Response $response)
+    public function enableCache(Response $response): static
     {
         if ($this->isViewCachedEnabled()) {
             $response->setPublic();
@@ -33,7 +32,7 @@ class ConfigurableResponseCacheConfigurator implements ResponseCacheConfigurator
         return $this;
     }
 
-    public function setSharedMaxAge(Response $response)
+    public function setSharedMaxAge(Response $response): static
     {
         if ($this->isViewCachedEnabled() && $this->isTTLCacheEnabled() && !$response->headers->hasCacheControlDirective('s-maxage')) {
             $response->setSharedMaxAge($this->getDefaultTTL());

--- a/src/lib/ResponseTagger/Delegator/ContentValueViewTagger.php
+++ b/src/lib/ResponseTagger/Delegator/ContentValueViewTagger.php
@@ -13,10 +13,7 @@ use Ibexa\Core\MVC\Symfony\View\ContentValueView;
 
 class ContentValueViewTagger implements ResponseTagger
 {
-    /**
-     * @var \Ibexa\Contracts\HttpCache\ResponseTagger\ResponseTagger
-     */
-    private $contentInfoTagger;
+    private ResponseTagger $contentInfoTagger;
 
     public function __construct(ResponseTagger $contentInfoTagger)
     {

--- a/src/lib/ResponseTagger/Delegator/DispatcherTagger.php
+++ b/src/lib/ResponseTagger/Delegator/DispatcherTagger.php
@@ -17,14 +17,14 @@ class DispatcherTagger implements ResponseTagger
     /**
      * @var \Ibexa\Contracts\HttpCache\ResponseTagger\ResponseTagger
      */
-    private $taggers = [];
+    private array $taggers;
 
     public function __construct(array $taggers = [])
     {
         $this->taggers = $taggers;
     }
 
-    public function tag($value)
+    public function tag($value): void
     {
         foreach ($this->taggers as $tagger) {
             $tagger->tag($value);

--- a/src/lib/ResponseTagger/Delegator/LocationValueViewTagger.php
+++ b/src/lib/ResponseTagger/Delegator/LocationValueViewTagger.php
@@ -13,10 +13,7 @@ use Ibexa\Core\MVC\Symfony\View\LocationValueView;
 
 class LocationValueViewTagger implements ResponseTagger
 {
-    /**
-     * @var \Ibexa\Contracts\HttpCache\ResponseTagger\ResponseTagger
-     */
-    private $locationTagger;
+    private ResponseTagger $locationTagger;
 
     public function __construct(ResponseTagger $locationTagger)
     {

--- a/src/lib/ResponseTagger/Value/AbstractValueTagger.php
+++ b/src/lib/ResponseTagger/Value/AbstractValueTagger.php
@@ -12,8 +12,7 @@ use Ibexa\Contracts\HttpCache\ResponseTagger\ResponseTagger;
 
 abstract class AbstractValueTagger implements ResponseTagger
 {
-    /** @var \FOS\HttpCache\ResponseTagger */
-    protected $responseTagger;
+    protected FosResponseTagger $responseTagger;
 
     public function __construct(FosResponseTagger $responseTagger)
     {

--- a/src/lib/ResponseTagger/Value/LocationTagger.php
+++ b/src/lib/ResponseTagger/Value/LocationTagger.php
@@ -25,7 +25,7 @@ class LocationTagger extends AbstractValueTagger
         $this->responseTagger->addTags([ContentTagInterface::PARENT_LOCATION_PREFIX . $value->parentLocationId]);
         $this->responseTagger->addTags(
             array_map(
-                static function ($pathItem) {
+                static function (string $pathItem): string {
                     return ContentTagInterface::PATH_PREFIX . $pathItem;
                 },
                 $value->path

--- a/tests/lib/ContextProvider/RoleIdentifyTest.php
+++ b/tests/lib/ContextProvider/RoleIdentifyTest.php
@@ -18,6 +18,7 @@ use Ibexa\Core\Repository\Permission\PermissionResolver;
 use Ibexa\Core\Repository\Repository;
 use Ibexa\Core\Repository\Values\User\UserRoleAssignment;
 use Ibexa\HttpCache\ContextProvider\RoleIdentify;
+use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 
 /**
@@ -28,12 +29,12 @@ class RoleIdentifyTest extends TestCase
     /**
      * @var \Ibexa\Contracts\Core\Repository\Repository|\PHPUnit_Framework_MockObject_MockObject
      */
-    private $repositoryMock;
+    private MockObject $repositoryMock;
 
     /**
      * @var \Ibexa\Contracts\Core\Repository\RoleService|\PHPUnit_Framework_MockObject_MockObject
      */
-    private $roleServiceMock;
+    private MockObject $roleServiceMock;
 
     protected function setUp(): void
     {
@@ -52,7 +53,7 @@ class RoleIdentifyTest extends TestCase
             ->willReturn($this->roleServiceMock);
     }
 
-    public function testSetIdentity()
+    public function testSetIdentity(): void
     {
         $user = $this->createMock(APIUser::class);
         $userReference = $this->createMock(UserReference::class);
@@ -146,7 +147,7 @@ class RoleIdentifyTest extends TestCase
         );
     }
 
-    private function generateRoleAssignmentMock(array $properties = [])
+    private function generateRoleAssignmentMock(array $properties = []): MockObject
     {
         return $this
             ->getMockBuilder(UserRoleAssignment::class)
@@ -154,7 +155,7 @@ class RoleIdentifyTest extends TestCase
             ->getMockForAbstractClass();
     }
 
-    private function generateRoleMock(array $properties = [])
+    private function generateRoleMock(array $properties = []): MockObject
     {
         return $this
             ->getMockBuilder(Role::class)
@@ -162,7 +163,7 @@ class RoleIdentifyTest extends TestCase
             ->getMockForAbstractClass();
     }
 
-    private function generateLimitationMock(array $properties = [])
+    private function generateLimitationMock(array $properties = []): MockObject
     {
         $limitationMock = $this
             ->getMockBuilder(RoleLimitation::class)
@@ -176,7 +177,7 @@ class RoleIdentifyTest extends TestCase
         return $limitationMock;
     }
 
-    protected function getPermissionResolverMock()
+    protected function getPermissionResolverMock(): MockObject
     {
         return $this
             ->getMockBuilder(PermissionResolver::class)
@@ -185,7 +186,7 @@ class RoleIdentifyTest extends TestCase
             ->getMock();
     }
 
-    protected function getUserServiceMock()
+    protected function getUserServiceMock(): MockObject
     {
         return $this
             ->getMockBuilder(UserService::class)

--- a/tests/lib/ContextProvider/RoleIdentifyTest.php
+++ b/tests/lib/ContextProvider/RoleIdentifyTest.php
@@ -26,15 +26,9 @@ use PHPUnit\Framework\TestCase;
  */
 class RoleIdentifyTest extends TestCase
 {
-    /**
-     * @var \Ibexa\Contracts\Core\Repository\Repository|\PHPUnit_Framework_MockObject_MockObject
-     */
-    private MockObject $repositoryMock;
+    private Repository & MockObject $repositoryMock;
 
-    /**
-     * @var \Ibexa\Contracts\Core\Repository\RoleService|\PHPUnit_Framework_MockObject_MockObject
-     */
-    private MockObject $roleServiceMock;
+    private RoleService & MockObject $roleServiceMock;
 
     protected function setUp(): void
     {
@@ -147,7 +141,7 @@ class RoleIdentifyTest extends TestCase
         );
     }
 
-    private function generateRoleAssignmentMock(array $properties = []): MockObject
+    private function generateRoleAssignmentMock(array $properties = []): UserRoleAssignment & MockObject
     {
         return $this
             ->getMockBuilder(UserRoleAssignment::class)
@@ -155,7 +149,7 @@ class RoleIdentifyTest extends TestCase
             ->getMockForAbstractClass();
     }
 
-    private function generateRoleMock(array $properties = []): MockObject
+    private function generateRoleMock(array $properties = []): Role & MockObject
     {
         return $this
             ->getMockBuilder(Role::class)
@@ -163,7 +157,7 @@ class RoleIdentifyTest extends TestCase
             ->getMockForAbstractClass();
     }
 
-    private function generateLimitationMock(array $properties = []): MockObject
+    private function generateLimitationMock(array $properties = []): RoleLimitation & MockObject
     {
         $limitationMock = $this
             ->getMockBuilder(RoleLimitation::class)
@@ -177,7 +171,7 @@ class RoleIdentifyTest extends TestCase
         return $limitationMock;
     }
 
-    protected function getPermissionResolverMock(): MockObject
+    protected function getPermissionResolverMock(): PermissionResolver & MockObject
     {
         return $this
             ->getMockBuilder(PermissionResolver::class)
@@ -186,7 +180,7 @@ class RoleIdentifyTest extends TestCase
             ->getMock();
     }
 
-    protected function getUserServiceMock(): MockObject
+    protected function getUserServiceMock(): UserService & MockObject
     {
         return $this
             ->getMockBuilder(UserService::class)

--- a/tests/lib/PurgeClient/LocalPurgeClientTest.php
+++ b/tests/lib/PurgeClient/LocalPurgeClientTest.php
@@ -14,8 +14,7 @@ use Toflar\Psr6HttpCacheStore\Psr6StoreInterface;
 
 class LocalPurgeClientTest extends TestCase
 {
-    /** @var \PHPUnit\Framework\MockObject\MockObject|\Toflar\Psr6HttpCacheStore\Psr6StoreInterface */
-    private MockObject $store;
+    private Psr6StoreInterface & MockObject $store;
 
     protected function setUp(): void
     {

--- a/tests/lib/PurgeClient/LocalPurgeClientTest.php
+++ b/tests/lib/PurgeClient/LocalPurgeClientTest.php
@@ -8,13 +8,14 @@
 namespace Ibexa\Tests\HttpCache\PurgeClient;
 
 use Ibexa\HttpCache\PurgeClient\LocalPurgeClient;
+use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use Toflar\Psr6HttpCacheStore\Psr6StoreInterface;
 
 class LocalPurgeClientTest extends TestCase
 {
     /** @var \PHPUnit\Framework\MockObject\MockObject|\Toflar\Psr6HttpCacheStore\Psr6StoreInterface */
-    private $store;
+    private MockObject $store;
 
     protected function setUp(): void
     {
@@ -22,10 +23,10 @@ class LocalPurgeClientTest extends TestCase
         $this->store = $this->createMock(Psr6StoreInterface::class);
     }
 
-    public function testPurge()
+    public function testPurge(): void
     {
         $keys = array_map(
-            static function ($id) {
+            static function ($id): string {
                 return "l$id";
             },
             [123, 456, 789]

--- a/tests/lib/PurgeClient/RepositoryPrefixDecoratorTest.php
+++ b/tests/lib/PurgeClient/RepositoryPrefixDecoratorTest.php
@@ -15,19 +15,10 @@ use PHPUnit\Framework\TestCase;
 
 class RepositoryPrefixDecoratorTest extends TestCase
 {
-    /**
-     * @var \Ibexa\Contracts\HttpCache\PurgeClient\PurgeClientInterface
-     */
-    private MockObject $purgeClientMock;
+    private PurgeClientInterface & MockObject $purgeClientMock;
 
-    /**
-     * @var \Ibexa\HttpCache\RepositoryTagPrefix
-     */
-    private MockObject $tagPrefixMock;
+    private RepositoryTagPrefix & MockObject $tagPrefixMock;
 
-    /**
-     * @var \Ibexa\HttpCache\PurgeClient\RepositoryPrefixDecorator
-     */
     private RepositoryPrefixDecorator $prefixDecorator;
 
     protected function setUp(): void

--- a/tests/lib/PurgeClient/RepositoryPrefixDecoratorTest.php
+++ b/tests/lib/PurgeClient/RepositoryPrefixDecoratorTest.php
@@ -10,6 +10,7 @@ namespace Ibexa\Tests\HttpCache\PurgeClient;
 use Ibexa\Contracts\HttpCache\PurgeClient\PurgeClientInterface;
 use Ibexa\HttpCache\PurgeClient\RepositoryPrefixDecorator;
 use Ibexa\HttpCache\RepositoryTagPrefix;
+use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 
 class RepositoryPrefixDecoratorTest extends TestCase
@@ -17,17 +18,17 @@ class RepositoryPrefixDecoratorTest extends TestCase
     /**
      * @var \Ibexa\Contracts\HttpCache\PurgeClient\PurgeClientInterface
      */
-    private $purgeClientMock;
+    private MockObject $purgeClientMock;
 
     /**
      * @var \Ibexa\HttpCache\RepositoryTagPrefix
      */
-    private $tagPrefixMock;
+    private MockObject $tagPrefixMock;
 
     /**
      * @var \Ibexa\HttpCache\PurgeClient\RepositoryPrefixDecorator
      */
-    private $prefixDecorator;
+    private RepositoryPrefixDecorator $prefixDecorator;
 
     protected function setUp(): void
     {
@@ -45,7 +46,7 @@ class RepositoryPrefixDecoratorTest extends TestCase
         parent::tearDown();
     }
 
-    public function testPurge()
+    public function testPurge(): void
     {
         $this->purgeClientMock
             ->expects(self::once())
@@ -60,7 +61,7 @@ class RepositoryPrefixDecoratorTest extends TestCase
         $this->prefixDecorator->purge(['l123', 'c44', 'ez-all']);
     }
 
-    public function testPurgeWithPrefix()
+    public function testPurgeWithPrefix(): void
     {
         $this->purgeClientMock
             ->expects(self::once())
@@ -75,7 +76,7 @@ class RepositoryPrefixDecoratorTest extends TestCase
         $this->prefixDecorator->purge(['l123', 'c44', 'ez-all']);
     }
 
-    public function testPurgeAll()
+    public function testPurgeAll(): void
     {
         $this->purgeClientMock
             ->expects(self::once())

--- a/tests/lib/PurgeClient/VarnishPurgeClientTest.php
+++ b/tests/lib/PurgeClient/VarnishPurgeClientTest.php
@@ -10,16 +10,17 @@ namespace Ibexa\Tests\HttpCache\PurgeClient;
 use FOS\HttpCache\ProxyClient\ProxyClient;
 use FOS\HttpCacheBundle\CacheManager;
 use Ibexa\HttpCache\PurgeClient\VarnishPurgeClient;
+use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
 
 class VarnishPurgeClientTest extends TestCase
 {
     /** @var \FOS\HttpCacheBundle\CacheManager */
-    private $cacheManager;
+    private MockObject $cacheManager;
 
     /** @var \Ibexa\HttpCache\PurgeClient\VarnishPurgeClient */
-    private $purgeClient;
+    private VarnishPurgeClient $purgeClient;
 
     protected function setUp(): void
     {
@@ -40,7 +41,7 @@ class VarnishPurgeClientTest extends TestCase
         );
     }
 
-    public function testPurgeNoLocationIds()
+    public function testPurgeNoLocationIds(): void
     {
         $this->cacheManager
             ->expects(self::never())
@@ -52,10 +53,10 @@ class VarnishPurgeClientTest extends TestCase
     /**
      * @dataProvider purgeTestProvider
      */
-    public function testPurge(array $locationIds)
+    public function testPurge(array $locationIds): void
     {
         $keys = array_map(
-            static function ($id) {
+            static function ($id): string {
                 return "l$id";
             },
             $locationIds
@@ -69,7 +70,7 @@ class VarnishPurgeClientTest extends TestCase
         $this->purgeClient->purge($keys);
     }
 
-    public function purgeTestProvider()
+    public function purgeTestProvider(): array
     {
         return [
             [[123]],
@@ -78,7 +79,7 @@ class VarnishPurgeClientTest extends TestCase
         ];
     }
 
-    public function testPurgeAll()
+    public function testPurgeAll(): void
     {
         $this->cacheManager
             ->expects(self::once())

--- a/tests/lib/PurgeClient/VarnishPurgeClientTest.php
+++ b/tests/lib/PurgeClient/VarnishPurgeClientTest.php
@@ -16,10 +16,8 @@ use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
 
 class VarnishPurgeClientTest extends TestCase
 {
-    /** @var \FOS\HttpCacheBundle\CacheManager */
-    private MockObject $cacheManager;
+    private CacheManager & MockObject $cacheManager;
 
-    /** @var \Ibexa\HttpCache\PurgeClient\VarnishPurgeClient */
     private VarnishPurgeClient $purgeClient;
 
     protected function setUp(): void


### PR DESCRIPTION
> [!CAUTION]
> These changes are volatile and - in some repositories - extensive, so they need to be carefully reviewed before merging.

| :ticket: Issue | IBX-9727 |
|----------------|-----------|

#### Description:

Added missing strict type hints using `\Rector\Set\ValueObject\SetList::TYPE_DECLARATION` set.
Additionally FQCNs have been imported for every affected file using PHP CS Fixer, in some cases they might override unrelated lines.

#### For QA:

Regression tests.
