### PR TITLE
Refactored tag handling methods to support numerical ids

### DIFF
--- a/src/lib/Handler/TagHandler.php
+++ b/src/lib/Handler/TagHandler.php
@@ -124,7 +124,7 @@ class TagHandler extends SymfonyResponseTagger implements ContentTagInterface
      */
     public function addContentTags(array $contentIds): void
     {
-        $this->addTags(array_map(static function (string $contentId): string {
+        $this->addTags(array_map(static function (string|int $contentId): string {
             return ContentTagInterface::CONTENT_PREFIX . $contentId;
         }, $contentIds));
     }
@@ -134,9 +134,11 @@ class TagHandler extends SymfonyResponseTagger implements ContentTagInterface
      */
     public function addLocationTags(array $locationIds): void
     {
-        $this->addTags(array_map(static function (string $locationId): string {
+        $tags = array_map(static function (string|int|null $locationId): string {
             return ContentTagInterface::LOCATION_PREFIX . $locationId;
-        }, $locationIds));
+        }, $locationIds);
+
+        $this->addTags($tags);
     }
 
     /**
@@ -144,7 +146,7 @@ class TagHandler extends SymfonyResponseTagger implements ContentTagInterface
      */
     public function addParentLocationTags(array $parentLocationIds): void
     {
-        $this->addTags(array_map(static function (string $parentLocationId): string {
+        $this->addTags(array_map(static function (string|int $parentLocationId): string {
             return ContentTagInterface::PARENT_LOCATION_PREFIX . $parentLocationId;
         }, $parentLocationIds));
     }
@@ -154,7 +156,7 @@ class TagHandler extends SymfonyResponseTagger implements ContentTagInterface
      */
     public function addPathTags(array $locationIds): void
     {
-        $this->addTags(array_map(static function (string $locationId): string {
+        $this->addTags(array_map(static function (string|int $locationId): string {
             return ContentTagInterface::PATH_PREFIX . $locationId;
         }, $locationIds));
     }
@@ -164,7 +166,7 @@ class TagHandler extends SymfonyResponseTagger implements ContentTagInterface
      */
     public function addRelationTags(array $contentIds): void
     {
-        $this->addTags(array_map(static function (string $contentId): string {
+        $this->addTags(array_map(static function (string|int $contentId): string {
             return ContentTagInterface::RELATION_PREFIX . $contentId;
         }, $contentIds));
     }
@@ -174,7 +176,7 @@ class TagHandler extends SymfonyResponseTagger implements ContentTagInterface
      */
     public function addRelationLocationTags(array $locationIds): void
     {
-        $this->addTags(array_map(static function (string $locationId): string {
+        $this->addTags(array_map(static function (string|int $locationId): string {
             return ContentTagInterface::RELATION_LOCATION_PREFIX . $locationId;
         }, $locationIds));
     }
@@ -184,7 +186,7 @@ class TagHandler extends SymfonyResponseTagger implements ContentTagInterface
      */
     public function addContentTypeTags(array $contentTypeIds): void
     {
-        $this->addTags(array_map(static function (string $contentTypeId): string {
+        $this->addTags(array_map(static function (string|int $contentTypeId): string {
             return ContentTagInterface::CONTENT_TYPE_PREFIX . $contentTypeId;
         }, $contentTypeIds));
     }


### PR DESCRIPTION
| :ticket: Issue | IBX-XXXXX |
|----------------|-----------|

<!-- 
#### Related PRs: 
- https://github.com/ibexa/core/pull/1
-->

#### Description:
Follow up for https://github.com/ibexa/http-cache/pull/63.

Issue detected by https://github.com/ibexa/fieldtype-page/actions/runs/14773790369/job/41478333517

```
    │  	[2025-05-01T10:26:13.389330+00:00] request.CRITICAL: Uncaught PHP Exception TypeError: "Ibexa\HttpCache\Handler\TagHandler::Ibexa\HttpCache\Handler\{closure}(): Argument #1 ($locationId) must be of type string, null given" at TagHandler.php line 137 {"exception":"[object] (TypeError(code: 0): Ibexa\\HttpCache\\Handler\\TagHandler::Ibexa\\HttpCache\\Handler\\{closure}(): Argument #1 ($locationId) must be of type string, null given at /var/www/vendor/ibexa/http-cache/src/lib/Handler/TagHandler.php:137)"} []
```

#### For QA:
N/A

#### Documentation:
N/A

<!-- 
Before you click submit:
    - Test the solution manually
    - Provide automated test coverage
    - Confirm that target branch is set correctly
    - For new features, confirm that you have suitable access control and injection prevention
    - Run PHP CS Fixer for new PHP code (use $ composer fix-cs)
    - Run ESLint and Prettier for new JS/SCSS code (use $ yarn fix)
    - Ask for a review (ping @ibexa/php-dev or @ibexa/javascript-dev depending on the changes) 
--> 
