### PR TITLE
IBX-8471: Fixed Varnish::queueRequest implementation after SF 7 upgrade

### DIFF
--- a/src/lib/ProxyClient/Varnish.php
+++ b/src/lib/ProxyClient/Varnish.php
@@ -9,10 +9,6 @@ declare(strict_types=1);
 namespace Ibexa\HttpCache\ProxyClient;
 
 use FOS\HttpCache\ProxyClient\Dispatcher;
-use FOS\HttpCache\ProxyClient\Invalidation\BanCapable;
-use FOS\HttpCache\ProxyClient\Invalidation\PurgeCapable;
-use FOS\HttpCache\ProxyClient\Invalidation\RefreshCapable;
-use FOS\HttpCache\ProxyClient\Invalidation\TagCapable;
 use FOS\HttpCache\ProxyClient\Varnish as FosVarnish;
 use Ibexa\Bundle\HttpCache\Controller\InvalidateTokenController;
 use Ibexa\Contracts\Core\SiteAccess\ConfigResolverInterface;
@@ -59,6 +55,6 @@ final class Varnish extends FosVarnish
         bool $validateHost = true,
         $body = null
     ): void {
-        parent::queueRequest($method, $url, $this->fetchAndMergeAuthHeaders($headers), body: $body);
+        parent::queueRequest($method, $url, $this->fetchAndMergeAuthHeaders($headers), $validateHost, $body);
     }
 }


### PR DESCRIPTION
> [!CAUTION]
> - [x] Drop TMP commits before merging

| :ticket: Issue | IBX-8471 |
|----------------|-----------|


#### Related PRs: 
- #59
- https://github.com/ibexa/rest/pull/167
- https://github.com/ibexa/oss/pull/219
- https://github.com/ibexa/gh-workflows/pull/61
- ibexa/docker#40

#### Description:

Passed missing `$validateHost` to parent `\FOS\HttpCache\ProxyClient\Varnish` in `\Ibexa\HttpCache\ProxyClient\Varnish::queueRequest` implementation.


#### For QA:

Passing regression tests.