### PR TITLE
IBX-XXXX: Replaced internal HttpKernel Extension usage in IbexaHttpCacheExtension

### DIFF
--- a/src/bundle/DependencyInjection/IbexaHttpCacheExtension.php
+++ b/src/bundle/DependencyInjection/IbexaHttpCacheExtension.php
@@ -12,9 +12,9 @@ use Ibexa\Bundle\Core\DependencyInjection\Configuration\ParserInterface;
 use Symfony\Component\Config\FileLocator;
 use Symfony\Component\Config\Resource\FileResource;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Extension\Extension;
 use Symfony\Component\DependencyInjection\Extension\PrependExtensionInterface;
 use Symfony\Component\DependencyInjection\Loader;
-use Symfony\Component\HttpKernel\DependencyInjection\Extension;
 use Symfony\Component\Yaml\Yaml;
 
 class IbexaHttpCacheExtension extends Extension implements PrependExtensionInterface


### PR DESCRIPTION
| :ticket: Issue | IBX-XXXXX |
|----------------|-----------|

#### Description:
This PR updates IbexaHttpCacheExtension to stop using the internal Symfony\Component\HttpKernel\DependencyInjection\Extension class, which has been marked as internal since Symfony 7.1 and is planned for deprecation in 8.1.

<!-- 
Before you click submit:
    - Test the solution manually
    - Provide automated test coverage
    - Confirm that target branch is set correctly
    - For new features, confirm that you have suitable access control and injection prevention
    - Run PHP CS Fixer for new PHP code (use $ composer fix-cs)
    - Run ESLint and Prettier for new JS/SCSS code (use $ yarn fix)
    - Ask for a review (ping @ibexa/php-dev or @ibexa/javascript-dev depending on the changes) 
--> 
