### PR TITLE
IBX-10705: Updated vcl to fix caching in dev env and re-enable symfony profiler

### DIFF
--- a/docs/varnish/vcl/varnish5.vcl
+++ b/docs/varnish/vcl/varnish5.vcl
@@ -52,7 +52,7 @@ sub vcl_recv {
         set req.http.cookie = ";" + req.http.cookie;
         set req.http.cookie = regsuball(req.http.cookie, "; +", ";");
         set req.http.cookie = regsuball(req.http.cookie, ";(IBX_SESSION_ID[^=]*)=", "; \1=");
-        set req.http.cookie = regsuball(req.http.cookie, ";(ibexa-[^=]*)=", "; \1=");
+        set req.http.cookie = regsuball(req.http.cookie, ";(ibexa[-_][^=]*)=", "; \1=");
         set req.http.cookie = regsuball(req.http.cookie, ";[^ ][^;]*", "");
         set req.http.cookie = regsuball(req.http.cookie, "^[; ]+|[; ]+$", "");
 

--- a/docs/varnish/vcl/varnish6.vcl
+++ b/docs/varnish/vcl/varnish6.vcl
@@ -52,7 +52,7 @@ sub vcl_recv {
         set req.http.cookie = ";" + req.http.cookie;
         set req.http.cookie = regsuball(req.http.cookie, "; +", ";");
         set req.http.cookie = regsuball(req.http.cookie, ";(IBX_SESSION_ID[^=]*)=", "; \1=");
-        set req.http.cookie = regsuball(req.http.cookie, ";(ibexa-[^=]*)=", "; \1=");
+        set req.http.cookie = regsuball(req.http.cookie, ";(ibexa[-_][^=]*)=", "; \1=");
         set req.http.cookie = regsuball(req.http.cookie, ";[^ ][^;]*", "");
         set req.http.cookie = regsuball(req.http.cookie, "^[; ]+|[; ]+$", "");
 

--- a/docs/varnish/vcl/varnish7.vcl
+++ b/docs/varnish/vcl/varnish7.vcl
@@ -50,7 +50,7 @@ sub vcl_recv {
         set req.http.cookie = ";" + req.http.cookie;
         set req.http.cookie = regsuball(req.http.cookie, "; +", ";");
         set req.http.cookie = regsuball(req.http.cookie, ";(IBX_SESSION_ID[^=]*)=", "; \1=");
-        set req.http.cookie = regsuball(req.http.cookie, ";(ibexa-[^=]*)=", "; \1=");
+        set req.http.cookie = regsuball(req.http.cookie, ";(ibexa[-_][^=]*)=", "; \1=");
         set req.http.cookie = regsuball(req.http.cookie, ";[^ ][^;]*", "");
         set req.http.cookie = regsuball(req.http.cookie, "^[; ]+|[; ]+$", "");
 


### PR DESCRIPTION
| :ticket: Issue | IBX-10705 |
|----------------|-----------|


#### Related PRs: 
- https://github.com/ibexa/post-install/pull/99
- https://github.com/ibexa/fastly/pull/49


#### Description:
As mentioned in the public ticket itself, Varnish fails to cache any content in `dev` env because the application sends profiler-related Set-Cookie headers, this change was introduced in 7.3 in `security-bundle` package.
I've updated VCL files to bring varnish and symfonys profiler back to working order.
The fix is up to debate, during the tests with @reithor and @vidarl we didn't discover any breaking issue.


<!-- 
Before you click submit:
    - Test the solution manually
    - Provide automated test coverage
    - Confirm that target branch is set correctly
    - For new features, confirm that you have suitable access control and injection prevention
    - Run PHP CS Fixer for new PHP code (use $ composer fix-cs)
    - Run ESLint and Prettier for new JS/SCSS code (use $ yarn fix)
    - Ask for a review (ping @ibexa/php-dev or @ibexa/javascript-dev depending on the changes) 
--> 
