### PR TITLE
IBX-11776: Fixed invalidating files when the content version didn't change

### DIFF
--- a/src/bundle/Resources/config/event.yml
+++ b/src/bundle/Resources/config/event.yml
@@ -12,9 +12,15 @@ services:
             $contentHandler: '@Ibexa\Core\Persistence\Cache\ContentHandler'
             $isTranslationAware: '%ibexa.http_cache.translation_aware.enabled%'
 
+    Ibexa\HttpCache\EventSubscriber\CachePurge\BinaryFileHttpCachePurgeSubscriber:
+        arguments:
+            $cacheManager: '@fos_http_cache.cache_manager'
+
     Ibexa\HttpCache\EventSubscriber\CachePurge\:
         resource: '../../../lib/EventSubscriber/CachePurge/*'
-        exclude: '../../../lib/EventSubscriber/CachePurge/ContentEventsSubscriber.php'
+        exclude:
+            - '../../../lib/EventSubscriber/CachePurge/ContentEventsSubscriber.php'
+            - '../../../lib/EventSubscriber/CachePurge/BinaryFileHttpCachePurgeSubscriber.php'
         arguments:
             $purgeClient: '@ibexa.http_cache.purge_client'
             $locationHandler: '@Ibexa\Core\Persistence\Cache\LocationHandler'

--- a/src/lib/EventSubscriber/CachePurge/BinaryFileHttpCachePurgeSubscriber.php
+++ b/src/lib/EventSubscriber/CachePurge/BinaryFileHttpCachePurgeSubscriber.php
@@ -1,0 +1,55 @@
+<?php
+
+/**
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace Ibexa\HttpCache\EventSubscriber\CachePurge;
+
+use FOS\HttpCacheBundle\CacheManager;
+use Ibexa\Contracts\Core\Repository\Events\Content\PublishVersionEvent;
+use Ibexa\Core\FieldType\BinaryBase\Value as BinaryBaseValue;
+use Ibexa\Core\FieldType\Image\Value as ImageValue;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+
+final class BinaryFileHttpCachePurgeSubscriber implements EventSubscriberInterface
+{
+    private CacheManager $cacheManager;
+
+    public function __construct(CacheManager $cacheManager)
+    {
+        $this->cacheManager = $cacheManager;
+    }
+
+    public static function getSubscribedEvents(): array
+    {
+        return [
+            PublishVersionEvent::class => 'onPublishVersion',
+        ];
+    }
+
+    public function onPublishVersion(PublishVersionEvent $event): void
+    {
+        $content = $event->getContent();
+        $purged = [];
+
+        foreach ($content->getFields() as $field) {
+            $value = $field->value;
+
+            if (!$value instanceof ImageValue && !$value instanceof BinaryBaseValue) {
+                continue;
+            }
+
+            $uri = $value->uri;
+
+            if ($uri === null || $uri === '' || isset($purged[$uri])) {
+                continue;
+            }
+
+            $this->cacheManager->invalidatePath($uri);
+            $purged[$uri] = true;
+        }
+    }
+}

--- a/src/lib/EventSubscriber/CachePurge/BinaryFileHttpCachePurgeSubscriber.php
+++ b/src/lib/EventSubscriber/CachePurge/BinaryFileHttpCachePurgeSubscriber.php
@@ -36,7 +36,7 @@ final class BinaryFileHttpCachePurgeSubscriber implements EventSubscriberInterfa
         $purged = [];
 
         foreach ($content->getFields() as $field) {
-            $value = $field->value;
+            $value = $field->getValue();
 
             if (!$value instanceof ImageValue && !$value instanceof BinaryBaseValue) {
                 continue;

--- a/tests/lib/EventSubscriber/CachePurge/BinaryFileHttpCachePurgeSubscriberTest.php
+++ b/tests/lib/EventSubscriber/CachePurge/BinaryFileHttpCachePurgeSubscriberTest.php
@@ -8,7 +8,7 @@ declare(strict_types=1);
 
 namespace Ibexa\Tests\HttpCache\EventSubscriber\CachePurge;
 
-use FOS\HttpCache\ProxyClient\ProxyClient;
+use FOS\HttpCache\ProxyClient\Invalidation\PurgeCapable;
 use FOS\HttpCacheBundle\CacheManager;
 use Ibexa\Contracts\Core\Repository\Events\Content\PublishVersionEvent;
 use Ibexa\Contracts\Core\Repository\Values\Content\Content;
@@ -22,25 +22,27 @@ use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
 
 final class BinaryFileHttpCachePurgeSubscriberTest extends TestCase
 {
-    private CacheManager $cacheManager;
+    private PurgeCapable $proxyClient;
 
     private BinaryFileHttpCachePurgeSubscriber $subscriber;
 
     protected function setUp(): void
     {
-        $this->cacheManager = $this->getMockBuilder(CacheManager::class)
-            ->setConstructorArgs([
-                $this->createMock(ProxyClient::class),
-                $this->createMock(UrlGeneratorInterface::class),
-            ])
-            ->getMock();
-
-        $this->subscriber = new BinaryFileHttpCachePurgeSubscriber($this->cacheManager);
+        $this->proxyClient = $this->createMock(PurgeCapable::class);
+        $this->subscriber = new BinaryFileHttpCachePurgeSubscriber(
+            new CacheManager(
+                $this->proxyClient,
+                $this->createMock(UrlGeneratorInterface::class)
+            ),
+        );
     }
 
     public function testGetSubscribedEvents(): void
     {
-        self::assertArrayHasKey(PublishVersionEvent::class, BinaryFileHttpCachePurgeSubscriber::getSubscribedEvents());
+        self::assertArrayHasKey(
+            PublishVersionEvent::class,
+            BinaryFileHttpCachePurgeSubscriber::getSubscribedEvents()
+        );
     }
 
     /**
@@ -58,19 +60,20 @@ final class BinaryFileHttpCachePurgeSubscriberTest extends TestCase
         );
     }
 
-    public function testNoFieldsDoesNotCallInvalidatePath(): void
+    public function testNoFieldsDoesNotCallPurge(): void
     {
-        $this->cacheManager->expects(self::never())->method('invalidatePath');
+        $this->proxyClient->expects(self::never())->method('purge');
 
         $this->subscriber->onPublishVersion($this->buildEvent([]));
     }
 
     public function testNonBinaryFieldIsSkipped(): void
     {
-        $this->cacheManager->expects(self::never())->method('invalidatePath');
+        $this->proxyClient->expects(self::never())->method('purge');
 
-        $field = new Field(['value' => new \stdClass()]);
-        $this->subscriber->onPublishVersion($this->buildEvent([$field]));
+        $this->subscriber->onPublishVersion($this->buildEvent([
+            new Field(['value' => new \stdClass()]),
+        ]));
     }
 
     public function testImageValueWithUriIsInvalidated(): void
@@ -78,10 +81,10 @@ final class BinaryFileHttpCachePurgeSubscriberTest extends TestCase
         $imageValue = new ImageValue();
         $imageValue->uri = '/var/site/storage/images/foo.jpg';
 
-        $this->cacheManager
+        $this->proxyClient
             ->expects(self::once())
-            ->method('invalidatePath')
-            ->with('/var/site/storage/images/foo.jpg');
+            ->method('purge')
+            ->with('/var/site/storage/images/foo.jpg', []);
 
         $this->subscriber->onPublishVersion($this->buildEvent([
             new Field(['value' => $imageValue]),
@@ -93,10 +96,10 @@ final class BinaryFileHttpCachePurgeSubscriberTest extends TestCase
         $binaryValue = new BinaryFileValue();
         $binaryValue->uri = '/var/site/storage/original/application/foo.pdf';
 
-        $this->cacheManager
+        $this->proxyClient
             ->expects(self::once())
-            ->method('invalidatePath')
-            ->with('/var/site/storage/original/application/foo.pdf');
+            ->method('purge')
+            ->with('/var/site/storage/original/application/foo.pdf', []);
 
         $this->subscriber->onPublishVersion($this->buildEvent([
             new Field(['value' => $binaryValue]),
@@ -108,7 +111,7 @@ final class BinaryFileHttpCachePurgeSubscriberTest extends TestCase
         $imageValue = new ImageValue();
         $imageValue->uri = null;
 
-        $this->cacheManager->expects(self::never())->method('invalidatePath');
+        $this->proxyClient->expects(self::never())->method('purge');
 
         $this->subscriber->onPublishVersion($this->buildEvent([
             new Field(['value' => $imageValue]),
@@ -120,7 +123,7 @@ final class BinaryFileHttpCachePurgeSubscriberTest extends TestCase
         $imageValue = new ImageValue();
         $imageValue->uri = '';
 
-        $this->cacheManager->expects(self::never())->method('invalidatePath');
+        $this->proxyClient->expects(self::never())->method('purge');
 
         $this->subscriber->onPublishVersion($this->buildEvent([
             new Field(['value' => $imageValue]),
@@ -137,10 +140,10 @@ final class BinaryFileHttpCachePurgeSubscriberTest extends TestCase
         $imageValue2 = new ImageValue();
         $imageValue2->uri = $uri;
 
-        $this->cacheManager
+        $this->proxyClient
             ->expects(self::once())
-            ->method('invalidatePath')
-            ->with($uri);
+            ->method('purge')
+            ->with($uri, []);
 
         $this->subscriber->onPublishVersion($this->buildEvent([
             new Field(['value' => $imageValue1]),
@@ -156,12 +159,12 @@ final class BinaryFileHttpCachePurgeSubscriberTest extends TestCase
         $binaryValue = new BinaryFileValue();
         $binaryValue->uri = '/var/site/storage/original/application/b.pdf';
 
-        $this->cacheManager
+        $this->proxyClient
             ->expects(self::exactly(2))
-            ->method('invalidatePath')
+            ->method('purge')
             ->withConsecutive(
-                ['/var/site/storage/images/a.jpg'],
-                ['/var/site/storage/original/application/b.pdf'],
+                ['/var/site/storage/images/a.jpg', []],
+                ['/var/site/storage/original/application/b.pdf', []],
             );
 
         $this->subscriber->onPublishVersion($this->buildEvent([
@@ -175,10 +178,10 @@ final class BinaryFileHttpCachePurgeSubscriberTest extends TestCase
         $imageValue = new ImageValue();
         $imageValue->uri = '/var/site/storage/images/photo.jpg';
 
-        $this->cacheManager
+        $this->proxyClient
             ->expects(self::once())
-            ->method('invalidatePath')
-            ->with('/var/site/storage/images/photo.jpg');
+            ->method('purge')
+            ->with('/var/site/storage/images/photo.jpg', []);
 
         $this->subscriber->onPublishVersion($this->buildEvent([
             new Field(['value' => 'plain text value']),

--- a/tests/lib/EventSubscriber/CachePurge/BinaryFileHttpCachePurgeSubscriberTest.php
+++ b/tests/lib/EventSubscriber/CachePurge/BinaryFileHttpCachePurgeSubscriberTest.php
@@ -1,0 +1,189 @@
+<?php
+
+/**
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace Ibexa\Tests\HttpCache\EventSubscriber\CachePurge;
+
+use FOS\HttpCache\ProxyClient\ProxyClient;
+use FOS\HttpCacheBundle\CacheManager;
+use Ibexa\Contracts\Core\Repository\Events\Content\PublishVersionEvent;
+use Ibexa\Contracts\Core\Repository\Values\Content\Content;
+use Ibexa\Contracts\Core\Repository\Values\Content\Field;
+use Ibexa\Contracts\Core\Repository\Values\Content\VersionInfo;
+use Ibexa\Core\FieldType\BinaryFile\Value as BinaryFileValue;
+use Ibexa\Core\FieldType\Image\Value as ImageValue;
+use Ibexa\HttpCache\EventSubscriber\CachePurge\BinaryFileHttpCachePurgeSubscriber;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
+
+final class BinaryFileHttpCachePurgeSubscriberTest extends TestCase
+{
+    private CacheManager $cacheManager;
+
+    private BinaryFileHttpCachePurgeSubscriber $subscriber;
+
+    protected function setUp(): void
+    {
+        $this->cacheManager = $this->getMockBuilder(CacheManager::class)
+            ->setConstructorArgs([
+                $this->createMock(ProxyClient::class),
+                $this->createMock(UrlGeneratorInterface::class),
+            ])
+            ->getMock();
+
+        $this->subscriber = new BinaryFileHttpCachePurgeSubscriber($this->cacheManager);
+    }
+
+    public function testGetSubscribedEvents(): void
+    {
+        self::assertArrayHasKey(PublishVersionEvent::class, BinaryFileHttpCachePurgeSubscriber::getSubscribedEvents());
+    }
+
+    /**
+     * @param \Ibexa\Contracts\Core\Repository\Values\Content\Field[] $fields
+     */
+    private function buildEvent(array $fields): PublishVersionEvent
+    {
+        $content = $this->createMock(Content::class);
+        $content->method('getFields')->willReturn($fields);
+
+        return new PublishVersionEvent(
+            $content,
+            $this->createMock(VersionInfo::class),
+            [],
+        );
+    }
+
+    public function testNoFieldsDoesNotCallInvalidatePath(): void
+    {
+        $this->cacheManager->expects(self::never())->method('invalidatePath');
+
+        $this->subscriber->onPublishVersion($this->buildEvent([]));
+    }
+
+    public function testNonBinaryFieldIsSkipped(): void
+    {
+        $this->cacheManager->expects(self::never())->method('invalidatePath');
+
+        $field = new Field(['value' => new \stdClass()]);
+        $this->subscriber->onPublishVersion($this->buildEvent([$field]));
+    }
+
+    public function testImageValueWithUriIsInvalidated(): void
+    {
+        $imageValue = new ImageValue();
+        $imageValue->uri = '/var/site/storage/images/foo.jpg';
+
+        $this->cacheManager
+            ->expects(self::once())
+            ->method('invalidatePath')
+            ->with('/var/site/storage/images/foo.jpg');
+
+        $this->subscriber->onPublishVersion($this->buildEvent([
+            new Field(['value' => $imageValue]),
+        ]));
+    }
+
+    public function testBinaryFileValueWithUriIsInvalidated(): void
+    {
+        $binaryValue = new BinaryFileValue();
+        $binaryValue->uri = '/var/site/storage/original/application/foo.pdf';
+
+        $this->cacheManager
+            ->expects(self::once())
+            ->method('invalidatePath')
+            ->with('/var/site/storage/original/application/foo.pdf');
+
+        $this->subscriber->onPublishVersion($this->buildEvent([
+            new Field(['value' => $binaryValue]),
+        ]));
+    }
+
+    public function testImageValueWithNullUriIsSkipped(): void
+    {
+        $imageValue = new ImageValue();
+        $imageValue->uri = null;
+
+        $this->cacheManager->expects(self::never())->method('invalidatePath');
+
+        $this->subscriber->onPublishVersion($this->buildEvent([
+            new Field(['value' => $imageValue]),
+        ]));
+    }
+
+    public function testImageValueWithEmptyUriIsSkipped(): void
+    {
+        $imageValue = new ImageValue();
+        $imageValue->uri = '';
+
+        $this->cacheManager->expects(self::never())->method('invalidatePath');
+
+        $this->subscriber->onPublishVersion($this->buildEvent([
+            new Field(['value' => $imageValue]),
+        ]));
+    }
+
+    public function testDuplicateUriIsInvalidatedOnlyOnce(): void
+    {
+        $uri = '/var/site/storage/images/same.jpg';
+
+        $imageValue1 = new ImageValue();
+        $imageValue1->uri = $uri;
+
+        $imageValue2 = new ImageValue();
+        $imageValue2->uri = $uri;
+
+        $this->cacheManager
+            ->expects(self::once())
+            ->method('invalidatePath')
+            ->with($uri);
+
+        $this->subscriber->onPublishVersion($this->buildEvent([
+            new Field(['value' => $imageValue1]),
+            new Field(['value' => $imageValue2]),
+        ]));
+    }
+
+    public function testMultipleDistinctUrisAreEachInvalidated(): void
+    {
+        $imageValue = new ImageValue();
+        $imageValue->uri = '/var/site/storage/images/a.jpg';
+
+        $binaryValue = new BinaryFileValue();
+        $binaryValue->uri = '/var/site/storage/original/application/b.pdf';
+
+        $this->cacheManager
+            ->expects(self::exactly(2))
+            ->method('invalidatePath')
+            ->withConsecutive(
+                ['/var/site/storage/images/a.jpg'],
+                ['/var/site/storage/original/application/b.pdf'],
+            );
+
+        $this->subscriber->onPublishVersion($this->buildEvent([
+            new Field(['value' => $imageValue]),
+            new Field(['value' => $binaryValue]),
+        ]));
+    }
+
+    public function testMixedFieldsOnlyInvalidatesBinaryAndImageUris(): void
+    {
+        $imageValue = new ImageValue();
+        $imageValue->uri = '/var/site/storage/images/photo.jpg';
+
+        $this->cacheManager
+            ->expects(self::once())
+            ->method('invalidatePath')
+            ->with('/var/site/storage/images/photo.jpg');
+
+        $this->subscriber->onPublishVersion($this->buildEvent([
+            new Field(['value' => 'plain text value']),
+            new Field(['value' => $imageValue]),
+            new Field(['value' => 42]),
+        ]));
+    }
+}

--- a/tests/lib/EventSubscriber/CachePurge/BinaryFileHttpCachePurgeSubscriberTest.php
+++ b/tests/lib/EventSubscriber/CachePurge/BinaryFileHttpCachePurgeSubscriberTest.php
@@ -60,74 +60,64 @@ final class BinaryFileHttpCachePurgeSubscriberTest extends TestCase
         );
     }
 
-    public function testNoFieldsDoesNotCallPurge(): void
+    /**
+     * @return iterable<string, array{\Ibexa\Contracts\Core\Repository\Values\Content\Field[]}>
+     */
+    public function fieldsThatDoNotTriggerPurgeProvider(): iterable
+    {
+        yield 'no fields' => [[]];
+
+        yield 'non-binary field value' => [[new Field(['value' => new \stdClass()])]];
+
+        $imageWithNullUri = new ImageValue();
+        $imageWithNullUri->uri = null;
+        yield 'image value with null URI' => [[new Field(['value' => $imageWithNullUri])]];
+
+        $imageWithEmptyUri = new ImageValue();
+        $imageWithEmptyUri->uri = '';
+        yield 'image value with empty URI' => [[new Field(['value' => $imageWithEmptyUri])]];
+    }
+
+    /**
+     * @dataProvider fieldsThatDoNotTriggerPurgeProvider
+     *
+     * @param \Ibexa\Contracts\Core\Repository\Values\Content\Field[] $fields
+     */
+    public function testFieldsThatDoNotTriggerPurge(array $fields): void
     {
         $this->proxyClient->expects(self::never())->method('purge');
 
-        $this->subscriber->onPublishVersion($this->buildEvent([]));
+        $this->subscriber->onPublishVersion($this->buildEvent($fields));
     }
 
-    public function testNonBinaryFieldIsSkipped(): void
-    {
-        $this->proxyClient->expects(self::never())->method('purge');
-
-        $this->subscriber->onPublishVersion($this->buildEvent([
-            new Field(['value' => new \stdClass()]),
-        ]));
-    }
-
-    public function testImageValueWithUriIsInvalidated(): void
+    /**
+     * @return iterable<string, array{\Ibexa\Contracts\Core\Repository\Values\Content\Field[], string}>
+     */
+    public function fieldsThatTriggerPurgeProvider(): iterable
     {
         $imageValue = new ImageValue();
         $imageValue->uri = '/var/site/storage/images/foo.jpg';
+        yield 'image value with URI' => [[new Field(['value' => $imageValue])], '/var/site/storage/images/foo.jpg'];
 
-        $this->proxyClient
-            ->expects(self::once())
-            ->method('purge')
-            ->with('/var/site/storage/images/foo.jpg', []);
-
-        $this->subscriber->onPublishVersion($this->buildEvent([
-            new Field(['value' => $imageValue]),
-        ]));
-    }
-
-    public function testBinaryFileValueWithUriIsInvalidated(): void
-    {
         $binaryValue = new BinaryFileValue();
         $binaryValue->uri = '/var/site/storage/original/application/foo.pdf';
+        yield 'binary file value with URI' => [[new Field(['value' => $binaryValue])], '/var/site/storage/original/application/foo.pdf'];
+    }
 
+    /**
+     * @dataProvider fieldsThatTriggerPurgeProvider
+     *
+     * @param \Ibexa\Contracts\Core\Repository\Values\Content\Field[] $fields
+     * @param string $expectedUri
+     */
+    public function testFieldsThatTriggerPurge(array $fields, string $expectedUri): void
+    {
         $this->proxyClient
             ->expects(self::once())
             ->method('purge')
-            ->with('/var/site/storage/original/application/foo.pdf', []);
+            ->with($expectedUri, []);
 
-        $this->subscriber->onPublishVersion($this->buildEvent([
-            new Field(['value' => $binaryValue]),
-        ]));
-    }
-
-    public function testImageValueWithNullUriIsSkipped(): void
-    {
-        $imageValue = new ImageValue();
-        $imageValue->uri = null;
-
-        $this->proxyClient->expects(self::never())->method('purge');
-
-        $this->subscriber->onPublishVersion($this->buildEvent([
-            new Field(['value' => $imageValue]),
-        ]));
-    }
-
-    public function testImageValueWithEmptyUriIsSkipped(): void
-    {
-        $imageValue = new ImageValue();
-        $imageValue->uri = '';
-
-        $this->proxyClient->expects(self::never())->method('purge');
-
-        $this->subscriber->onPublishVersion($this->buildEvent([
-            new Field(['value' => $imageValue]),
-        ]));
+        $this->subscriber->onPublishVersion($this->buildEvent($fields));
     }
 
     public function testDuplicateUriIsInvalidatedOnlyOnce(): void


### PR DESCRIPTION
| :ticket: Issue | IBX-11776|
|----------------|-----------|

<!-- 
#### Related PRs: 
- https://github.com/ibexa/core/pull/1
-->

#### Description:

This bug happens when we have a draft and we are making changes in this draft (in our case - the image).
Since the files are served without tagging by default, regular tag invalidation that happens when publishing content is not enough to refresh the changes.
In our logic, since it is still a draft, the content version didn't change ergo the file is presented when published without any changes. Without this fix to see the changes we would need to republish the content once again.
I have added a subscriber `BinaryFileHttpCachePurgeSubscriber` that explicitly purges the URI for ezimage, ezbinaryfile, and ezmedia when publishing the content.


<!-- 
Before you click submit:
    - Test the solution manually
    - Provide automated test coverage
    - Confirm that target branch is set correctly
    - For new features, confirm that you have suitable access control and injection prevention
    - Run PHP CS Fixer for new PHP code (use $ composer fix-cs)
    - Run ESLint and Prettier for new JS/SCSS code (use $ yarn fix)
    - Ask for a review (ping @ibexa/php-dev or @ibexa/javascript-dev depending on the changes) 
--> 
