### PR TITLE
IBX-11786: Kept Raptor Smart Advisor anonymous visitor identifier in Varnish configuration.

### DIFF
--- a/docs/varnish/vcl/varnish5.vcl
+++ b/docs/varnish/vcl/varnish5.vcl
@@ -53,6 +53,8 @@ sub vcl_recv {
         set req.http.cookie = regsuball(req.http.cookie, "; +", ";");
         set req.http.cookie = regsuball(req.http.cookie, ";(IBX_SESSION_ID[^=]*)=", "; \1=");
         set req.http.cookie = regsuball(req.http.cookie, ";(ibexa[-_][^=]*)=", "; \1=");
+        // Keep the Raptor anonymous visitor identifier cookie so CDP segmentation can resolve visitor segments.
+        set req.http.cookie = regsuball(req.http.cookie, ";(rsa)=", "; \1=");
         set req.http.cookie = regsuball(req.http.cookie, ";[^ ][^;]*", "");
         set req.http.cookie = regsuball(req.http.cookie, "^[; ]+|[; ]+$", "");
 

--- a/docs/varnish/vcl/varnish6.vcl
+++ b/docs/varnish/vcl/varnish6.vcl
@@ -53,7 +53,7 @@ sub vcl_recv {
         set req.http.cookie = regsuball(req.http.cookie, "; +", ";");
         set req.http.cookie = regsuball(req.http.cookie, ";(IBX_SESSION_ID[^=]*)=", "; \1=");
         set req.http.cookie = regsuball(req.http.cookie, ";(ibexa[-_][^=]*)=", "; \1=");
-        // Keep the Raptor Smart Advisor anonymous visitor identifier so CDP segmentation can resolve visitor segments.
+        // Keep the Raptor anonymous visitor identifier cookie so CDP segmentation can resolve visitor segments.
         set req.http.cookie = regsuball(req.http.cookie, ";(rsa)=", "; \1=");
         set req.http.cookie = regsuball(req.http.cookie, ";[^ ][^;]*", "");
         set req.http.cookie = regsuball(req.http.cookie, "^[; ]+|[; ]+$", "");

--- a/docs/varnish/vcl/varnish6.vcl
+++ b/docs/varnish/vcl/varnish6.vcl
@@ -53,6 +53,8 @@ sub vcl_recv {
         set req.http.cookie = regsuball(req.http.cookie, "; +", ";");
         set req.http.cookie = regsuball(req.http.cookie, ";(IBX_SESSION_ID[^=]*)=", "; \1=");
         set req.http.cookie = regsuball(req.http.cookie, ";(ibexa[-_][^=]*)=", "; \1=");
+        // Keep the Raptor Smart Advisor anonymous visitor identifier so CDP segmentation can resolve visitor segments.
+        set req.http.cookie = regsuball(req.http.cookie, ";(rsa)=", "; \1=");
         set req.http.cookie = regsuball(req.http.cookie, ";[^ ][^;]*", "");
         set req.http.cookie = regsuball(req.http.cookie, "^[; ]+|[; ]+$", "");
 

--- a/docs/varnish/vcl/varnish7.vcl
+++ b/docs/varnish/vcl/varnish7.vcl
@@ -51,6 +51,8 @@ sub vcl_recv {
         set req.http.cookie = regsuball(req.http.cookie, "; +", ";");
         set req.http.cookie = regsuball(req.http.cookie, ";(IBX_SESSION_ID[^=]*)=", "; \1=");
         set req.http.cookie = regsuball(req.http.cookie, ";(ibexa[-_][^=]*)=", "; \1=");
+        // Keep the Raptor anonymous visitor identifier cookie so CDP segmentation can resolve visitor segments.
+        set req.http.cookie = regsuball(req.http.cookie, ";(rsa)=", "; \1=");
         set req.http.cookie = regsuball(req.http.cookie, ";[^ ][^;]*", "");
         set req.http.cookie = regsuball(req.http.cookie, "^[; ]+|[; ]+$", "");
 


### PR DESCRIPTION
| :ticket: Issue | IBX-11786 |
|----------------|-----------|


#### Related PRs: 
https://github.com/ibexa/segmentation/pull/170


#### Description:

Forwarding `rsa` cookie in the Varnish 5/6/7 example configuration.

The `rsa` cookie is used by Connector Raptor/CDP as the anonymous visitor identifier for segment resolution. Keeping it in the forwarded cookie list allows backend segmentation logic to resolve visitor segments when requests pass through Varnish.

#### For QA:
<!-- Optional. Replace this comment with any necessary information needed by QA to test this Pull Request -->

#### Documentation:
<!-- Optional. Replace this comment with details helpful for writing the doc: overview, code snippets for extensibility etc. -->


<!-- 
Before you click submit:
    - Test the solution manually
    - Provide automated test coverage
    - Confirm that target branch is set correctly
    - For new features, confirm that you have suitable access control and injection prevention
    - Run PHP CS Fixer for new PHP code (use $ composer fix-cs)
    - Run ESLint and Prettier for new JS/SCSS code (use $ yarn fix)
    - Ask for a review (ping @ibexa/php-dev or @ibexa/javascript-dev depending on the changes) 
--> 
