### PR TITLE
IBX-12244: Restored refresh-instead-of-stale for logged-in users on Varnish 7

### DIFF
--- a/docs/varnish/vcl/varnish7.vcl
+++ b/docs/varnish/vcl/varnish7.vcl
@@ -60,6 +60,13 @@ sub vcl_recv {
         }
     }
 
+    // Logged-in users must not be served stale content while the backend is healthy: drop their
+    // grace allowance so an expired object is refetched rather than delivered from the grace
+    // window. varnish5/6.vcl do this in vcl_hit with return (miss), which later versions do not support.
+    if (req.http.cookie && std.healthy(req.backend_hint)) {
+        set req.grace = 0s;
+    }
+
     // Do a standard lookup on assets (these don't vary by user context hash)
     // Note that file extension list below is not extensive, so consider completing it to fit your needs.
     if (req.url ~ "\.(css|js|gif|jpe?g|bmp|png|tiff?|ico|img|tga|wmf|svg|swf|ico|mp3|mp4|m4a|ogg|mov|avi|wmv|zip|gz|pdf|ttf|eot|wof)$") {
@@ -91,7 +98,7 @@ sub vcl_backend_response {
         set beresp.do_esi = true;
     }
 
-    // Make Varnish keep all objects for up to 1 hour beyond their TTL, see vcl_hit for Request logic on this
+    // Make Varnish keep all objects for up to 1 hour beyond their TTL, see vcl_recv for Request logic on this
     // This will make Varnish to refresh objects in cache after 1 hour
     // The total time object can be in cache is 70 minutes (grace + keep time)
     set beresp.grace = 1h;

--- a/features/varnish/ttl.feature
+++ b/features/varnish/ttl.feature
@@ -83,14 +83,11 @@ Feature: As a site administrator I want Varnish to apply the configured TTL and 
             | Header      | Pattern        |
             | x-cache-ttl | /^[0-4]\.\d+$/ |
 
-    @varnish6
+    @varnish6 @varnish7
     Scenario: A logged-in user in the grace window gets a refreshed response, not a stale one
-        # varnish6.vcl vcl_hit: when the request carries a session cookie and the object is in
-        # grace, it does return (miss) so that editors are never shown stale content.
-        # varnish7.vcl has no vcl_hit at all and cannot be given the same one, because
-        # return (miss) was removed from that subroutine in Varnish 7 - so Varnish 7 and later
-        # deliver the stale object here instead. Tracked as a separate ticket; once varnish7.vcl
-        # gains the equivalent (return (pass)), this scenario can be tagged @varnish7 as well.
+        # Editors must never be shown stale content. varnish5/6.vcl enforce that in vcl_hit with
+        # return (miss); varnish7.vcl drops the grace allowance in vcl_recv instead, because later
+        # Varnish versions no longer support return (miss) there.
         Given I create "Folder" Content items in root in "eng-GB"
             | name       | short_name         |
             | TestFolder | StaleAdminTestItem |


### PR DESCRIPTION

| :ticket: Issue | IBX-12244 |
|----------------|-----------|

> [!CAUTION]
>  This PR Depends on #85 so base branch is set to [IBX-12241-varnish-cache-behat](https://github.com/ibexa/http-cache/tree/IBX-12241-varnish-cache-behat). However, do not merge into [IBX-12241-varnish-cache-behat](https://github.com/ibexa/http-cache/tree/IBX-12241-varnish-cache-behat). Instead it should be merged into 46 once #85 has been merged there.
#### Description:

`varnish5.vcl` and `varnish6.vcl` calls `return (miss)` from `vcl_hit` to prevent logged-in users
from receiving stale content. Calling `return (miss)` from `vcl_hit` is not supported in varnish7
and later. And the functionality was never ported to the varnish7 vcl.
This caps the grace period per request in `vcl_recv` instead, right after cookie normalisation so
only surviving session cookies count:

```vcl
if (req.http.cookie && std.healthy(req.backend_hint)) {
    set req.grace = 0s;
}
```


#### For QA:

FYI : Due to #85, there is now a behat test for this specific case:
> Scenario: A logged-in user in the grace window gets a refreshed response, not a stale one

#### Documentation:


